### PR TITLE
Update client URL to https://ud.me

### DIFF
--- a/packages/config/CHANGELOG.md
+++ b/packages/config/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.0.5
+
+- Change the client URL to https://ud.me
+
 ## 0.0.2
 
 - Update the README to include usage examples

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unstoppabledomains/config",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "private": true,
   "description": "Configuration variables for Unstoppable Domains environments",
   "homepage": "https://github.com/unstoppabledomains/domain-profiles#readme",

--- a/packages/config/src/env/production.ts
+++ b/packages/config/src/env/production.ts
@@ -3,7 +3,7 @@ import type {ConfigOverride} from './types';
 export default function getProductionConfig(): ConfigOverride {
   return {
     APP_ENV: 'production',
-    UD_ME_BASE_URL: 'https://domain-profiles-wnjctwcyaa-uc.a.run.app',
+    UD_ME_BASE_URL: 'https://ud.me',
     UNSTOPPABLE_API_URL: 'https://api.unstoppabledomains.com',
     UNSTOPPABLE_WEBSITE_URL: 'https://unstoppabledomains.com',
     UNSTOPPABLE_METADATA_ENDPOINT:
@@ -37,7 +37,7 @@ export default function getProductionConfig(): ConfigOverride {
     },
     LOGIN_WITH_UNSTOPPABLE: {
       CLIENT_ID: 'c3af833f-3fd5-46fd-ac3e-bfc136624d1b',
-      REDIRECT_URI: 'https://domain-profiles-wnjctwcyaa-uc.a.run.app',
+      REDIRECT_URI: 'https://ud.me',
     },
     MESSAGING: {
       EMAIL_DOMAIN: 'ud.me',


### PR DESCRIPTION
As part of the migration to https://ud.me, the config client URL must be updated.