### PR TITLE
Lazy load conversation preview

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "packages/*"
   ],
   "scripts": {
-    "build": "rm -rf packages/**/build; yarn build:types",
+    "build": "yarn build:types",
     "build:types": "tsc --build packages.build.tsconfig.json",
     "copy-package-files": "./scripts/copyPackageFiles.sh",
-    "dist": "yarn build && yarn copy-package-files",
+    "dist": "rm -rf packages/**/build && yarn build && yarn copy-package-files",
     "format": "prettier -w .",
     "lint": "eslint --fix .",
     "test": "DOTENV_CONFIG_PATH=./.env.test jest --runInBand",

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -91,6 +91,7 @@
     "truncate-eth-address": "^1.0.2",
     "tss-react": "^4.0.0",
     "typescript": "5.0.4",
+    "usehooks-ts": "^2.9.1",
     "wagmi": "^1.4.4",
     "web3.storage": "^4.5.5"
   },

--- a/packages/ui-components/src/components/Chat/modal/dm/ConversationPreview.tsx
+++ b/packages/ui-components/src/components/Chat/modal/dm/ConversationPreview.tsx
@@ -28,6 +28,8 @@ const useStyles = makeStyles()((theme: Theme) => ({
     paddingBottom: theme.spacing(2),
     marginRight: theme.spacing(1),
     borderBottom: '1px dashed #eeeeee',
+    height: '70px',
+    alignItems: 'center',
   },
   avatar: {
     marginRight: theme.spacing(2),

--- a/packages/ui-components/src/components/Chat/modal/dm/ConversationPreview.tsx
+++ b/packages/ui-components/src/components/Chat/modal/dm/ConversationPreview.tsx
@@ -18,6 +18,7 @@ import {isAddressSpam} from '../../../../actions/messageActions';
 import useTranslationContext from '../../../../lib/i18n';
 import {getAddressMetadata} from '../../protocol/resolution';
 import type {ConversationMeta} from '../../protocol/xmtp';
+import {getConversationPreview} from '../../protocol/xmtp';
 
 const useStyles = makeStyles()((theme: Theme) => ({
   conversationContainer: {
@@ -105,6 +106,9 @@ export const ConversationPreview: React.FC<ConversationPreviewProps> = ({
     const loadAddressData = async () => {
       // if conversation is not accepted, check spam score
       if (!acceptedTopics.find(v => v === conversation.conversation.topic)) {
+        // get message preview
+        await getConversationPreview(conversation);
+
         // check peer address spam score
         if (await isAddressSpam(conversation.conversation.peerAddress)) {
           setIsSpam(true);
@@ -148,34 +152,36 @@ export const ConversationPreview: React.FC<ConversationPreviewProps> = ({
   return isVisible ? (
     <Box ref={nodeRef}>
       {isLoaded ? (
-        <Box
-          className={classes.conversationContainer}
-          onClick={() => selectedCallback(conversation.conversation)}
-        >
-          <Box>
-            <Avatar src={avatarLink} className={classes.avatar} />
-          </Box>
-          <Box className={classes.chatPreview}>
-            <Box className={classes.chatHeader}>
-              <Typography variant="subtitle2">{displayName}</Typography>
-              <Box className={classes.chatTimestamp}>
-                <Typography variant="caption">
-                  {moment(conversation.timestamp).fromNow()}
-                </Typography>
-              </Box>
+        conversation.timestamp > 0 && (
+          <Box
+            className={classes.conversationContainer}
+            onClick={() => selectedCallback(conversation.conversation)}
+          >
+            <Box>
+              <Avatar src={avatarLink} className={classes.avatar} />
             </Box>
-            <Typography variant="body2">
-              {isSpam ? (
-                <Box className={classes.warningContainer}>
-                  <WarningAmberOutlinedIcon className={classes.warningIcon} />
-                  {t('push.spamWarning')}
+            <Box className={classes.chatPreview}>
+              <Box className={classes.chatHeader}>
+                <Typography variant="subtitle2">{displayName}</Typography>
+                <Box className={classes.chatTimestamp}>
+                  <Typography variant="caption">
+                    {moment(conversation.timestamp).fromNow()}
+                  </Typography>
                 </Box>
-              ) : (
-                <Emoji>{conversation.preview}</Emoji>
-              )}
-            </Typography>
+              </Box>
+              <Typography variant="body2">
+                {isSpam ? (
+                  <Box className={classes.warningContainer}>
+                    <WarningAmberOutlinedIcon className={classes.warningIcon} />
+                    {t('push.spamWarning')}
+                  </Box>
+                ) : (
+                  <Emoji>{conversation.preview}</Emoji>
+                )}
+              </Typography>
+            </Box>
           </Box>
-        </Box>
+        )
       ) : (
         <Box className={classes.conversationContainer}>
           <Box>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4513,6 +4513,7 @@ __metadata:
     tslib: ^2.6.2
     tss-react: ^4.0.0
     typescript: 5.0.4
+    usehooks-ts: ^2.9.1
     wagmi: ^1.4.4
     web3.storage: ^4.5.5
   languageName: unknown
@@ -17334,6 +17335,16 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
   checksum: 5c639e0f8da3521d605f59ce5be9e094ca772bd44a4ce7322b055a6f58eeed8dda3c94cabd90c7a41fb6fa852210092008afe48f7038792fd47501f33299116a
+  languageName: node
+  linkType: hard
+
+"usehooks-ts@npm:^2.9.1":
+  version: 2.9.1
+  resolution: "usehooks-ts@npm:2.9.1"
+  peerDependencies:
+    react: ^16.8.0  || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0  || ^17.0.0 || ^18.0.0
+  checksum: 36f1e4142ce23bc019b81d2e93aefd7f2c350abcf255598c21627114a69a2f2f116b35dc3a353375f09c6e4c9b704a04f104e3d10e98280545c097feca66c30a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The current implementation does a lot of pre-loading of XMTP conversation data. This approach does not scale well for accounts with large number of existing conversations. The new implementation only renders conversation data for elements that are currently visible on the screen.