### PR TITLE
Request only the required profile data

### DIFF
--- a/packages/ui-components/src/actions/domainProfileActions.ts
+++ b/packages/ui-components/src/actions/domainProfileActions.ts
@@ -7,6 +7,7 @@ import type {AddressResolution} from '../components/Chat/types';
 import type {NftResponse} from '../lib';
 import {fetchApi} from '../lib/fetchApi';
 import type {
+  DomainFieldTypes,
   SerializedFollowerListData,
   SerializedPublicDomainProfileData,
 } from '../lib/types/domain';
@@ -88,11 +89,13 @@ export const getFollowers = async (
 
 export const getProfileData = async (
   domain: string,
+  fields: DomainFieldTypes[],
   expiry?: number,
 ): Promise<SerializedPublicDomainProfileData | undefined> => {
-  const domainProfileUrl = `/public/${domain}${
-    expiry ? `?expiry=${expiry}` : ''
-  }`;
+  const domainProfileUrl = `/public/${domain}?${QueryString.stringify({
+    expiry,
+    fields: fields ? fields.join(',') : undefined,
+  })}`;
   return await fetchApi(domainProfileUrl, {host: config.PROFILE.HOST_URL});
 };
 

--- a/packages/ui-components/src/components/Chat/modal/group/CommunityList.tsx
+++ b/packages/ui-components/src/components/Chat/modal/group/CommunityList.tsx
@@ -14,7 +14,10 @@ import {getDomainBadges} from '../../../../actions/domainActions';
 import {getProfileData} from '../../../../actions/domainProfileActions';
 import useTranslationContext from '../../../../lib/i18n';
 import type {SerializedCryptoWalletBadge} from '../../../../lib/types/badge';
-import {UD_BLUE_BADGE_CODE} from '../../../../lib/types/domain';
+import {
+  DomainFieldTypes,
+  UD_BLUE_BADGE_CODE,
+} from '../../../../lib/types/domain';
 import {getGroupInfo} from '../../protocol/push';
 import CommunityPreview from './CommunityPreview';
 
@@ -92,7 +95,7 @@ export const CommunityList: React.FC<CommunityListProps> = ({
     setLoadingText(t('push.loadingCommunities'));
     const [badgeData, domainProfile] = await Promise.all([
       getDomainBadges(domain, {withoutPartners: true}),
-      getProfileData(domain, Date.now()),
+      getProfileData(domain, [DomainFieldTypes.Profile], Date.now()),
     ]);
 
     // determine group membership

--- a/packages/ui-components/src/components/Domain/DomainPreview.tsx
+++ b/packages/ui-components/src/components/Domain/DomainPreview.tsx
@@ -22,6 +22,7 @@ import {notifyError} from '../../lib/error';
 import useTranslationContext from '../../lib/i18n';
 import type {SerializedPublicDomainProfileData} from '../../lib/types/domain';
 import {
+  DomainFieldTypes,
   DomainProfileKeys,
   DomainSuffixes,
   Web2SuffixesList,
@@ -137,7 +138,9 @@ export const DomainPreview: React.FC<DomainPreviewProps> = ({
     }
     const fetchData = async () => {
       try {
-        const profileJSON = await getProfileData(domain);
+        const profileJSON = await getProfileData(domain, [
+          DomainFieldTypes.Profile,
+        ]);
         if (profileJSON) {
           setProfileData(profileJSON);
         }

--- a/packages/ui-components/src/components/Header/AccountButton.tsx
+++ b/packages/ui-components/src/components/Header/AccountButton.tsx
@@ -10,7 +10,7 @@ import {getProfileData} from '../../actions/domainProfileActions';
 import DropDownMenu from '../../components/DropDownMenu';
 import getImageUrl from '../../lib/domain/getImageUrl';
 import {notifyError} from '../../lib/error';
-import type {SerializedPublicDomainProfileData} from '../../lib/types/domain';
+import {DomainFieldTypes, type SerializedPublicDomainProfileData} from '../../lib/types/domain';
 
 const useStyles = makeStyles()((theme: Theme) => ({
   profileButtonContainer: {
@@ -95,7 +95,7 @@ export const AccountButton: React.FC<AccountButtonProps> = ({
     const fetchData = async (domainName: string) => {
       let profileData;
       try {
-        profileData = await getProfileData(domainName);
+        profileData = await getProfileData(domainName, [DomainFieldTypes.Profile]);
       } catch {}
       setAuthDomainAvatar(
         getDomainAvatarFromProfileAndMetadata(domainName, profileData),

--- a/packages/ui-components/src/lib/types/domain.ts
+++ b/packages/ui-components/src/lib/types/domain.ts
@@ -34,6 +34,18 @@ export type DomainDescription = {
   sld: string | null;
 };
 
+export enum DomainFieldTypes {
+  CryptoVerifications = 'cryptoVerifications',
+  HumanityCheck = 'humanityCheck',
+  Messaging = 'messaging',
+  Profile = 'profile',
+  SocialAccounts = 'socialAccounts',
+  Records = 'records',
+  ReferralCode = 'referralCode',
+  ReferralTier = 'referralTier',
+  WebacyScore = 'webacyScore',
+}
+
 export enum DomainProfileKeys {
   AuthAddress = 'authAddress',
   AuthDomain = 'authDomain',


### PR DESCRIPTION
Update the `getProfileData()` method to require the requested fields to be provided explicitly. Ensures the app is only requesting the data it needs, and not causing server processing delays without reason.