### PR TITLE
Render on-chain records at client side

### DIFF
--- a/packages/ui-components/src/components/CryptoAddresses/CryptoAddress.tsx
+++ b/packages/ui-components/src/components/CryptoAddresses/CryptoAddress.tsx
@@ -37,6 +37,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
     alignItems: 'center',
     justifyContent: 'space-between',
     cursor: 'pointer',
+    minWidth: '150px',
     transition: theme.transitions.create([
       'background-color',
       'box-shadow',

--- a/server/pages/[domain]/index.page.test.tsx
+++ b/server/pages/[domain]/index.page.test.tsx
@@ -3,7 +3,10 @@ import userEvent from '@testing-library/user-event';
 import React from 'react';
 import {customRender} from 'tests/test-utils';
 
-import type {DomainBadgesResponse} from '@unstoppabledomains/ui-components';
+import type {
+  DomainBadgesResponse,
+  SerializedPublicDomainProfileData,
+} from '@unstoppabledomains/ui-components';
 import {
   DomainProfileKeys,
   PersonaInquiryStatus,
@@ -88,6 +91,11 @@ const defaultProps = (): DomainProfilePageProps => {
         },
       },
     },
+  };
+};
+
+const defaultRecords = () => {
+  return {
     records: {
       'whois.email.value': 'user@test.com',
       'whois.for_sale.value': 'true',
@@ -101,6 +109,23 @@ const defaultProps = (): DomainProfilePageProps => {
       namehash: '0x1234',
       registry: '0x1234',
       resolver: '0x1234',
+    },
+  };
+};
+
+const defaultProfileData = (): SerializedPublicDomainProfileData => {
+  return {
+    ...defaultProps().profileData!,
+    ...defaultRecords(),
+  };
+};
+
+const defaultTokenGalleryData = (): SerializedPublicDomainProfileData => {
+  return {
+    ...defaultProfileData(),
+    records: {
+      'crypto.ETH.address': 'test-eth-address',
+      'crypto.SOL.address': 'test-sol-address',
     },
   };
 };
@@ -161,7 +186,7 @@ describe('<DomainProfile />', () => {
     });
     jest
       .spyOn(domainProfileActions, 'getProfileData')
-      .mockResolvedValue(defaultProps().profileData!);
+      .mockResolvedValue(defaultProfileData());
     jest
       .spyOn(featureFlagActions, 'fetchFeatureFlags')
       .mockResolvedValue(featureFlagActions.DEFAULT_FEATURE_FLAGS);
@@ -232,35 +257,45 @@ describe('<DomainProfile />', () => {
     });
   });
 
-  it('shows empty case if the domain not minted', () => {
+  it('shows empty case if the domain not minted', async () => {
     const props = defaultProps();
-    props.metadata = {};
     props.profileData = null;
-    props.records = {};
+
+    jest.spyOn(domainProfileActions, 'getProfileData').mockResolvedValue({
+      ...defaultProfileData(),
+      records: {},
+      metadata: {},
+    });
 
     customRender(<DomainProfile {...props} />);
 
-    expect(
-      screen.getByText("The domain is purchased but isn't minted yet."),
-    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.getByText("The domain is purchased but isn't minted yet."),
+      ).toBeInTheDocument();
+    });
   });
 
-  it('renders a crypto address', () => {
+  it('renders a crypto address', async () => {
     const props = defaultProps();
-    props.records['crypto.ETH.address'] =
-      '0x82fb235d3338c5583512f2065555dc18fe13a12b';
+
+    jest.spyOn(domainProfileActions, 'getProfileData').mockResolvedValue({
+      ...defaultProfileData(),
+      records: {
+        'crypto.ETH.address': '0x82fb235d3338c5583512f2065555dc18fe13a12b',
+      },
+    });
+
     customRender(<DomainProfile {...props} />);
 
-    expect(screen.getByText('0x82...a12b')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('0x82...a12b')).toBeInTheDocument();
+    });
   });
 });
 
 describe('Token gallery for multiple blockchains', () => {
   const tokenGalleryProps = defaultProps();
-  tokenGalleryProps.records = {
-    'crypto.ETH.address': 'test-eth-address',
-    'crypto.SOL.address': 'test-sol-address',
-  };
   tokenGalleryProps.profileData!.profile.tokenGalleryEnabled = true;
 
   beforeEach(async () => {
@@ -305,7 +340,7 @@ describe('Token gallery for multiple blockchains', () => {
     // mock profile with token gallery enabled
     jest
       .spyOn(domainProfileActions, 'getProfileData')
-      .mockResolvedValue(tokenGalleryProps.profileData!);
+      .mockResolvedValue(defaultTokenGalleryData());
 
     // mock NFT data
     jest.spyOn(domainProfileActions, 'getDomainNfts').mockResolvedValue({
@@ -566,10 +601,6 @@ describe('Token gallery for multiple blockchains', () => {
 
 describe('Token gallery for single blockchain', () => {
   const tokenGalleryProps = defaultProps();
-  tokenGalleryProps.records = {
-    'crypto.ETH.address': 'test-eth-address',
-    'crypto.SOL.address': 'test-sol-address',
-  };
   tokenGalleryProps.profileData!.profile.tokenGalleryEnabled = true;
 
   beforeEach(async () => {
@@ -614,7 +645,7 @@ describe('Token gallery for single blockchain', () => {
     // mock profile with token gallery enabled
     jest
       .spyOn(domainProfileActions, 'getProfileData')
-      .mockResolvedValue(tokenGalleryProps.profileData!);
+      .mockResolvedValue(defaultTokenGalleryData());
 
     // mock NFT data
     jest.spyOn(domainProfileActions, 'getDomainNfts').mockResolvedValue({
@@ -698,10 +729,6 @@ describe('Token gallery for single blockchain', () => {
 
 describe('Token gallery carousel', () => {
   const tokenGalleryProps = defaultProps();
-  tokenGalleryProps.records = {
-    'crypto.ETH.address': 'test-eth-address',
-    'crypto.SOL.address': 'test-sol-address',
-  };
   tokenGalleryProps.profileData!.profile.tokenGalleryEnabled = true;
 
   beforeEach(async () => {
@@ -746,7 +773,7 @@ describe('Token gallery carousel', () => {
     // mock profile with token gallery enabled
     jest
       .spyOn(domainProfileActions, 'getProfileData')
-      .mockResolvedValue(tokenGalleryProps.profileData!);
+      .mockResolvedValue(defaultTokenGalleryData());
 
     // mock NFT data
     jest.spyOn(domainProfileActions, 'getDomainNfts').mockResolvedValue({
@@ -1020,10 +1047,6 @@ describe('Token gallery carousel', () => {
 
 describe('Owner operations', () => {
   const tokenGalleryProps = defaultProps();
-  tokenGalleryProps.records = {
-    'crypto.ETH.address': 'test-eth-address',
-    'crypto.SOL.address': 'test-sol-address',
-  };
   tokenGalleryProps.profileData!.profile.tokenGalleryEnabled = true;
 
   beforeEach(async () => {
@@ -1068,7 +1091,7 @@ describe('Owner operations', () => {
     // mock profile with token gallery enabled
     jest
       .spyOn(domainProfileActions, 'getProfileData')
-      .mockResolvedValue(tokenGalleryProps.profileData!);
+      .mockResolvedValue(defaultTokenGalleryData());
 
     // mock NFT data
     jest.spyOn(domainProfileActions, 'getDomainNfts').mockResolvedValue({
@@ -1145,7 +1168,7 @@ describe('Owner operations', () => {
       .mockImplementation((k: string): string | null => {
         switch (k) {
           case DomainProfileKeys.AuthAddress:
-            return defaultProps().metadata.owner;
+            return defaultProfileData()!.metadata!.owner;
           case DomainProfileKeys.AuthDomain:
             return 'foo.crypto';
         }

--- a/server/pages/[domain]/index.page.test.tsx
+++ b/server/pages/[domain]/index.page.test.tsx
@@ -127,6 +127,15 @@ const defaultTokenGalleryData = (): SerializedPublicDomainProfileData => {
       'crypto.ETH.address': 'test-eth-address',
       'crypto.SOL.address': 'test-sol-address',
     },
+    cryptoVerifications: [
+      {
+        id: 0,
+        symbol: 'ETH',
+        address: 'test-eth-address',
+        plaintextMessage: 'message',
+        signedMessage: 'signature',
+      },
+    ],
   };
 };
 

--- a/server/pages/[domain]/index.page.tsx
+++ b/server/pages/[domain]/index.page.tsx
@@ -890,15 +890,16 @@ const DomainProfile = ({
         </Grid>
 
         <Grid item xs={12} sm={12} md={8} className={classes.item}>
-          {profileData?.profile.tokenGalleryEnabled && (
-            <TokenGallery
-              domain={domain}
-              enabled={!isExternalDomain && isFeatureFlagFetched}
-              isOwner={isOwner}
-              ownerAddress={ownerAddress}
-              profileServiceUrl={config.PROFILE.HOST_URL}
-            />
-          )}
+          {profileData?.cryptoVerifications &&
+            profileData.cryptoVerifications.length > 0 && (
+              <TokenGallery
+                domain={domain}
+                enabled={!isExternalDomain && isFeatureFlagFetched}
+                isOwner={isOwner}
+                ownerAddress={ownerAddress}
+                profileServiceUrl={config.PROFILE.HOST_URL}
+              />
+            )}
           {isForSale && !nftShowAll && openSeaLink && (
             <ForSaleOnOpenSea email={ownerEmail} link={openSeaLink} />
           )}


### PR DESCRIPTION
Instead of retrieving the on-chain records as part of the main `/public/<domain>` request to the profile API, render them on the client side at page load time. This will enable improved cache management with faster and more accurate display of on-chain records.