### PR TITLE
Use UI-kit as peer dependency

### DIFF
--- a/packages/ui-components/CHANGELOG.md
+++ b/packages/ui-components/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.27
+
+- Move `@unstoppabledomains/ui-kit` to peerDependencies
+
 ## 0.0.26
 
 - Improve XMTP conversation list loading time

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unstoppabledomains/ui-components",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "private": true,
   "description": "An open and reusable suite of Unstoppable Domains management components",
   "keywords": [

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -48,7 +48,6 @@
     "@uauth/js": "^2.8.0",
     "@unstoppabledomains/config": "workspace:^",
     "@unstoppabledomains/resolution": "^8.5.0",
-    "@unstoppabledomains/ui-kit": "^0.3.15",
     "@web3-react/core": "^8.2.2",
     "@xmtp/content-type-remote-attachment": "^1.0.7",
     "@xmtp/proto": "^3.27.0",
@@ -112,5 +111,8 @@
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/"
+  },
+  "peerDependencies": {
+    "@unstoppabledomains/ui-kit": "^0.3.15"
   }
 }

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unstoppabledomains/ui-components",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "private": true,
   "description": "An open and reusable suite of Unstoppable Domains management components",
   "keywords": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -4465,7 +4465,6 @@ __metadata:
     "@uauth/js": ^2.8.0
     "@unstoppabledomains/config": "workspace:^"
     "@unstoppabledomains/resolution": ^8.5.0
-    "@unstoppabledomains/ui-kit": ^0.3.15
     "@web3-react/core": ^8.2.2
     "@xmtp/content-type-remote-attachment": ^1.0.7
     "@xmtp/proto": ^3.27.0
@@ -4516,6 +4515,8 @@ __metadata:
     usehooks-ts: ^2.9.1
     wagmi: ^1.4.4
     web3.storage: ^4.5.5
+  peerDependencies:
+    "@unstoppabledomains/ui-kit": ^0.3.15
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Dependents of this package will likely want to use their own UI-kit context. To allow them to do this, we need to move the UI-kit depending on the peers.