### PR TITLE
Move from chat context dependence to passing props

### DIFF
--- a/packages/ui-components/CHANGELOG.md
+++ b/packages/ui-components/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.0.30
+
+- `<DomainPreview />` - move from Chat dependencies to passing props
+
 ## 0.0.29
 
 - Bump Push Protocol library to latest version

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unstoppabledomains/ui-components",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "private": true,
   "description": "An open and reusable suite of Unstoppable Domains management components",
   "keywords": [

--- a/packages/ui-components/src/components/Badges/BadgePopupModal.tsx
+++ b/packages/ui-components/src/components/Badges/BadgePopupModal.tsx
@@ -93,7 +93,7 @@ const BadgePopupModal = ({
   const [t] = useTranslationContext();
   const {classes, cx} = useStyles();
   const {setOpenCommunity} = useUnstoppableMessaging();
-  const {chatUser} = useUnstoppableMessaging();
+  const {chatUser, setOpenChat} = useUnstoppableMessaging();
   const [openPopover, setOpenPopover] = useState(false);
   const [openComposeMessageModal, setOpenComposeMessageModal] = useState(false);
   const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(
@@ -309,6 +309,8 @@ const BadgePopupModal = ({
                         key={`holder-${badgeCode}-${holdersDomain}`}
                         domain={holdersDomain}
                         size={20}
+                        chatUser={chatUser}
+                        setOpenChat={setOpenChat}
                         setWeb3Deps={setWeb3Deps}
                       />
                     ))}

--- a/packages/ui-components/src/components/Domain/DomainPreview.tsx
+++ b/packages/ui-components/src/components/Domain/DomainPreview.tsx
@@ -15,7 +15,6 @@ import {makeStyles} from '@unstoppabledomains/ui-kit/styles';
 
 import {getProfileData} from '../../actions';
 import {useFeatureFlags} from '../../actions/featureFlagActions';
-import useUnstoppableMessaging from '../../hooks/useUnstoppableMessaging';
 import {splitDomain} from '../../lib/domain/format';
 import getImageUrl from '../../lib/domain/getImageUrl';
 import {notifyError} from '../../lib/error';
@@ -100,13 +99,14 @@ const useStyles = makeStyles<{size: number}>()((theme: Theme, {size}) => ({
 export const DomainPreview: React.FC<DomainPreviewProps> = ({
   domain,
   size,
+  chatUser,
+  setOpenChat,
   setWeb3Deps,
 }) => {
   const [t] = useTranslationContext();
   const {classes} = useStyles({size});
   const [profileData, setProfileData] =
     useState<SerializedPublicDomainProfileData>();
-  const {chatUser, setOpenChat} = useUnstoppableMessaging();
   const {data: featureFlags} = useFeatureFlags();
   const [authAddress, setAuthAddress] = useState<string>();
   const [authDomain, setAuthDomain] = useState<string>();
@@ -270,6 +270,7 @@ export const DomainPreview: React.FC<DomainPreviewProps> = ({
                     ?.ecommerceServiceUsersEnableChat && (
                     <Grid item sm={chatUser ? 6 : 12}>
                       {chatUser &&
+                        setOpenChat &&
                         authDomain &&
                         authAddress &&
                         authDomain.toLowerCase() !== domain.toLowerCase() && (
@@ -298,5 +299,7 @@ export const DomainPreview: React.FC<DomainPreviewProps> = ({
 export type DomainPreviewProps = {
   domain: string;
   size: number;
+  chatUser?: string;
+  setOpenChat?: (s?: string) => void;
   setWeb3Deps?: (value: Web3Dependencies | undefined) => void;
 };

--- a/server/pages/[domain]/index.page.tsx
+++ b/server/pages/[domain]/index.page.tsx
@@ -657,6 +657,8 @@ const DomainProfile = ({
                             <DomainPreview
                               domain={follower}
                               size={30}
+                              chatUser={chatUser}
+                              setOpenChat={setOpenChat}
                               setWeb3Deps={setWeb3Deps}
                             />
                           ))}


### PR DESCRIPTION
To allow using `<DomainPreview />` component without Messaging context, would be good to pass current dependencies via props.