### PR TITLE
Enable token gallery for ENS domains

### DIFF
--- a/packages/ui-components/src/components/Chat/UnstoppableMessaging.tsx
+++ b/packages/ui-components/src/components/Chat/UnstoppableMessaging.tsx
@@ -476,7 +476,6 @@ export const UnstoppableMessaging: React.FC<UnstoppableMessagingProps> = ({
                   env: config.APP_ENV === 'production' ? ENV.PROD : ENV.STAGING,
                   profile: {
                     name: chatUser,
-                    picture: `${config.UNSTOPPABLE_METADATA_ENDPOINT}/image-src/${chatUser}?withOverlay=false`,
                   },
                 });
               }

--- a/server/pages/[domain]/index.page.tsx
+++ b/server/pages/[domain]/index.page.tsx
@@ -147,8 +147,8 @@ const DomainProfile = ({
   );
   const [optimisticFollowCount, setOptimisticFollowCount] = useState(0);
 
-  const isExternalDomain = isExternalDomainValidForManagement(domain);
-  const {data: ethDomainStatus} = useEnsDomainStatus(domain, isExternalDomain);
+  const isEnsDomain = isExternalDomainValidForManagement(domain);
+  const {data: ethDomainStatus} = useEnsDomainStatus(domain, isEnsDomain);
 
   // format social platform data
   const socialsInfo: SerializedDomainProfileSocialAccountsUserInfo = {};
@@ -906,7 +906,7 @@ const DomainProfile = ({
               profileData.cryptoVerifications.length > 0 && (
                 <TokenGallery
                   domain={domain}
-                  enabled={!isExternalDomain && isFeatureFlagFetched}
+                  enabled={isFeatureFlagFetched}
                   isOwner={isOwner}
                   ownerAddress={ownerAddress}
                   profileServiceUrl={config.PROFILE.HOST_URL}
@@ -1173,7 +1173,7 @@ const DomainProfile = ({
                   : t('profile.emptyNotMinted')}
               </div>
             )}
-            {isExternalDomain && ethDomainStatus?.expiresAt && (
+            {isEnsDomain && ethDomainStatus?.expiresAt && (
               <div className={classes.empty}>
                 {t('profile.thisDomainExpires', {
                   action: isPast(new Date(ethDomainStatus.expiresAt))


### PR DESCRIPTION
The feature was previously disabled for non-Unstoppable domains. This PR opens the feature to all domains, provided the domain's on-chain records include verified ownership proofs.