### PR TITLE
Normalize IPFS hash

### DIFF
--- a/client.jest.config.ts
+++ b/client.jest.config.ts
@@ -27,6 +27,7 @@ const config: InitialOptionsTsJest = {
       },
     ],
   },
+  moduleDirectories: ['node_modules', '<rootDir>/server'],
   testPathIgnorePatterns: ['/node_modules/', '/build/'],
   moduleNameMapper: {
     ['@xmtp/(.*)']: '<rootDir>/tests/mocks/empty.js',

--- a/packages/config/src/env/default.ts
+++ b/packages/config/src/env/default.ts
@@ -46,7 +46,7 @@ export default function getDefaultConfig(): Config {
       'https://storage.googleapis.com/unstoppable-client-assets',
     UNSTOPPABLE_CONTRACT_ADDRESS: '0xa9a6a3626993d487d2dbda3173cf58ca1a9d9e9f',
     UNSTOPPABLE_METADATA_ENDPOINT: 'https://api.ud-staging.com/metadata',
-    IPFS_BASE_URL: 'https://ipfs.io/ipfs',
+    IPFS_BASE_URL: 'https://ipfs.io',
     VERIFICATION_SUPPORTED: [
       'SOL',
       'ETH',

--- a/server/lib/ipfs.test.ts
+++ b/server/lib/ipfs.test.ts
@@ -1,0 +1,23 @@
+import {normalizeIpfsHash} from './ipfs';
+
+describe('IPFS', () => {
+  it('should add /ipfs prefix to plain hash', () => {
+    const normalizedHash = normalizeIpfsHash('someHash');
+    expect(normalizedHash).toBe('/ipfs/someHash');
+  });
+
+  it('should add /ipfs prefix to hash with path', () => {
+    const normalizedHash = normalizeIpfsHash('someHash/file.txt');
+    expect(normalizedHash).toBe('/ipfs/someHash/file.txt');
+  });
+
+  it('should retain existing /ipfs prefix', () => {
+    const normalizedHash = normalizeIpfsHash('/ipfs/someHash');
+    expect(normalizedHash).toBe('/ipfs/someHash');
+  });
+
+  it('should retain existing /ipns prefix', () => {
+    const normalizedHash = normalizeIpfsHash('/ipns/someHash');
+    expect(normalizedHash).toBe('/ipns/someHash');
+  });
+});

--- a/server/lib/ipfs.ts
+++ b/server/lib/ipfs.ts
@@ -1,0 +1,6 @@
+export const normalizeIpfsHash = (hash: string): string => {
+  if (hash.match(/^\/ip(f|n)s\/.*$/)) {
+    return hash;
+  }
+  return `/ipfs/${hash}`;
+};

--- a/server/pages/[domain]/index.page.tsx
+++ b/server/pages/[domain]/index.page.tsx
@@ -22,6 +22,7 @@ import Typography from '@mui/material/Typography';
 import {useTheme} from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import {format, isPast} from 'date-fns';
+import {normalizeIpfsHash} from 'lib/ipfs';
 import type {GetServerSideProps} from 'next';
 import {NextSeo} from 'next-seo';
 import {useSnackbar} from 'notistack';
@@ -856,7 +857,9 @@ const DomainProfile = ({
                     <LanguageIcon className={classes.sidebarIcon} />
                     <Link
                       external
-                      href={`${config.IPFS_BASE_URL}/${ipfsHash}`}
+                      href={`${config.IPFS_BASE_URL}/${normalizeIpfsHash(
+                        ipfsHash,
+                      )}`}
                       className={classes.websiteLink}
                     >
                       {`${domain} (${ipfsHash.slice(0, 10)}...${ipfsHash.slice(


### PR DESCRIPTION
If an IPFS content record is provided, it should be normalized to account for known prefixes like `/ipfs` and `/ipns`. If a known prefix is not provided with the hash, use a default prefix `/ipfs`