### PR TITLE
Include domain records on SRR rendering

### DIFF
--- a/server/pages/[domain]/index.page.tsx
+++ b/server/pages/[domain]/index.page.tsx
@@ -1245,6 +1245,7 @@ export async function getServerSideProps(props: DomainProfileServerSideProps) {
         DomainFieldTypes.Messaging,
         DomainFieldTypes.Profile,
         DomainFieldTypes.SocialAccounts,
+        DomainFieldTypes.Records,
       ]),
       getIdentity({name: domain}),
     ]);


### PR DESCRIPTION
In order to support rendering on-chain PFPs, the records must be requested at SSR rendering time. This PR adds the `records` to the profile data fields requested during SSR.