### PR TITLE
Ensure Push Protocol SDK at latest version

### DIFF
--- a/packages/ui-components/src/components/Wallet/ProfileManager.tsx
+++ b/packages/ui-components/src/components/Wallet/ProfileManager.tsx
@@ -21,6 +21,8 @@ export type ManagerProps = {
   setSaveClicked: (value: boolean) => void;
   onSignature: (signature: string, expiry: string) => void;
   onFailed?: () => void;
+  useLocalPushKey?: boolean;
+  useLocalXmtpKey?: boolean;
 };
 
 export const ONE_WEEK = 60 * 60 * 24 * 7 * 1000;
@@ -33,6 +35,8 @@ export const ProfileManager: React.FC<ManagerProps> = ({
   setSaveClicked,
   onSignature,
   onFailed,
+  useLocalXmtpKey = true,
+  useLocalPushKey = false,
 }) => {
   const web3Context = useContext(Web3Context);
   const [messageResponse, setMessageResponse] = useState<MessageResponse>();
@@ -107,7 +111,7 @@ export const ProfileManager: React.FC<ManagerProps> = ({
 
     // sign with locally stored XMTP key if available
     const localXmtpKey = getXmtpLocalKey(ownerAddress);
-    if (localXmtpKey) {
+    if (localXmtpKey && useLocalXmtpKey) {
       const xmtpSignatureBytes = new Signature(
         await signXmtpMessage(ownerAddress, responseBody.message),
       ).toBytes();
@@ -123,7 +127,7 @@ export const ProfileManager: React.FC<ManagerProps> = ({
 
     // sign with a locally stored Push Protocol key if available
     const localPushKey = getPushLocalKey(ownerAddress);
-    if (localPushKey) {
+    if (localPushKey && useLocalPushKey) {
       const pushSignature = await signPushMessage(
         responseBody.message,
         localPushKey,

--- a/server/package.json
+++ b/server/package.json
@@ -25,8 +25,6 @@
   "dependencies": {
     "@braintree/sanitize-url": "^6.0.4",
     "@emotion/server": "^11.4.0",
-    "@pushprotocol/restapi": "^1.4.15",
-    "@pushprotocol/socket": "^0.5.1",
     "@swc/cli": "^0.1.57",
     "@swc/core": "^1.2.219",
     "@types/bluebird": "3.5.34",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2740,33 +2740,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pushprotocol/restapi@npm:^1.4.15":
-  version: 1.4.24
-  resolution: "@pushprotocol/restapi@npm:1.4.24"
-  dependencies:
-    "@ambire/signature-validator": ^1.3.1
-    "@metamask/eth-sig-util": ^5.0.2
-    "@pushprotocol/socket": ^0.5.2
-    axios: ^0.27.2
-    buffer: ^6.0.3
-    crypto-js: ^4.1.1
-    immer: ^10.0.2
-    joi: ^17.9.2
-    livepeer: ^2.5.8
-    openpgp: ^5.5.0
-    simple-peer: ^9.11.1
-    socket.io-client: ^4.5.2
-    tslib: ^2.3.0
-    unique-names-generator: ^4.7.1
-    uuid: ^9.0.0
-    video-stream-merger: ^4.0.1
-    viem: ^1.3.0
-  peerDependencies:
-    ethers: ^5.6.8
-  checksum: 79921942883b87e90f363763a1a0e7e5dd51421802d21511cb04a5113e901eba2c7afe32793d233b00a84a9694908a1dbe8c3875c2dfb201b647e704844c4f42
-  languageName: node
-  linkType: hard
-
 "@pushprotocol/socket@npm:^0.5.1, @pushprotocol/socket@npm:^0.5.2":
   version: 0.5.2
   resolution: "@pushprotocol/socket@npm:0.5.2"
@@ -15492,8 +15465,6 @@ __metadata:
     "@braintree/sanitize-url": ^6.0.4
     "@emotion/server": ^11.4.0
     "@next/swc-linux-x64-gnu": ^12.2.5
-    "@pushprotocol/restapi": ^1.4.15
-    "@pushprotocol/socket": ^0.5.1
     "@swc/cli": ^0.1.57
     "@swc/core": ^1.2.219
     "@swc/jest": ^0.2.22


### PR DESCRIPTION
Ensure the latest version of the Push Protocol alpha SDK is being referenced by node_modules build. The `/server` package was importing the stable SDK version, while the `ui-components` package was importing the alpha. This caused the SDK to be an unexpected level at build time, and features not working as expected.