### PR TITLE
HOTFIX: Typecheck webacy results

### DIFF
--- a/server/pages/[domain]/index.page.tsx
+++ b/server/pages/[domain]/index.page.tsx
@@ -853,8 +853,8 @@ const DomainProfile = ({
                             <>
                               <Typography variant="caption">
                                 {
-                                  issue.categories.wallet_characteristics
-                                    .description
+                                  issue.categories?.wallet_characteristics
+                                    ?.description
                                 }
                               </Typography>
                               <List dense sx={{listStyleType: 'disc', pl: 4}}>


### PR DESCRIPTION
When processing Webacy data, incorrect assumptions were made about the structure of the return format. Null checking should handle data that is received in different format.