### PR TITLE
Use correct smart contract address for ENS listing on OpenSea

### DIFF
--- a/packages/config/src/env/default.ts
+++ b/packages/config/src/env/default.ts
@@ -23,7 +23,8 @@ export default function getDefaultConfig(): Config {
         BLOCK_EXPLORER_BASE_URL: 'https://goerli.etherscan.io',
         DISABLE_CONTRACTS_CACHE: true,
         PROXY_READER_ADDRESS: '0xFc5f608149f4D9e2Ed0733efFe9DD57ee24BCF68',
-        OPEN_SEA_BASE_URL: 'https://testnets.opensea.io/assets/',
+        OPEN_SEA_BASE_URL: 'https://testnets.opensea.io/assets/goerli/',
+        ENS_CONTRACT_ADDRESS: '0x114d4603199df73e7d157787f8778e21fcd13066',
       },
       MATIC: {
         CHAIN_ID: 80001,

--- a/packages/config/src/env/production.ts
+++ b/packages/config/src/env/production.ts
@@ -24,6 +24,7 @@ export default function getProductionConfig(): ConfigOverride {
         BLOCK_EXPLORER_BASE_URL: 'https://etherscan.io',
         PROXY_READER_ADDRESS: '0xc3C2BAB5e3e52DBF311b2aAcEf2e40344f19494E',
         OPEN_SEA_BASE_URL: 'https://opensea.io/assets/',
+        ENS_CONTRACT_ADDRESS: '0x57f1887a8BF19b14fC0dF6Fd9B2acc9Af147eA85',
       },
       MATIC: {
         CHAIN_ID: 137,

--- a/packages/config/src/env/types.ts
+++ b/packages/config/src/env/types.ts
@@ -20,9 +20,11 @@ export type EthereumBlockchainConfig = BaseBlockchainConfig & {
   CHAIN_ID: 5 | 1 | 1337;
   NETWORK_NAME: 'goerli' | 'mainnet' | 'local';
   PROXY_READER_ADDRESS: string;
+  ENS_CONTRACT_ADDRESS: string;
   OPEN_SEA_BASE_URL:
     | 'https://opensea.io/assets/'
-    | 'https://testnets.opensea.io/assets/';
+    | 'https://testnets.opensea.io/assets/'
+    | 'https://testnets.opensea.io/assets/goerli/';
 };
 
 export type MaticBlockchainConfig = BaseBlockchainConfig & {

--- a/packages/ui-components/src/lib/formOpenseaLink.ts
+++ b/packages/ui-components/src/lib/formOpenseaLink.ts
@@ -1,12 +1,15 @@
 import config from '@unstoppabledomains/config';
 
 import type {EvmBlockchain, Meta} from './types/blockchain';
-import {Blockchain} from './types/blockchain';
+import {Blockchain, Registry} from './types/blockchain';
 
 export const formOpenSeaLink = (domainMeta: Meta) => {
   let url: null | string = null;
 
-  const registryAddress = domainMeta.registryAddress;
+  const registryAddress =
+    domainMeta.type === Registry.ENS
+      ? config.BLOCKCHAINS.ETH.ENS_CONTRACT_ADDRESS
+      : domainMeta.registryAddress;
   const blockchain = domainMeta.blockchain;
 
   if (!blockchain || blockchain === Blockchain.ZIL) {

--- a/server/pages/[domain]/index.page.tsx
+++ b/server/pages/[domain]/index.page.tsx
@@ -200,7 +200,7 @@ const DomainProfile = ({
   const openSeaLink = formOpenSeaLink({
     logicalOwnerAddress: ownerAddress,
     blockchain: blockchain as Blockchain,
-    type: Registry.UNS,
+    type: isEnsDomain ? Registry.ENS : Registry.UNS,
     ttl: 0,
     tokenId,
     domain,


### PR DESCRIPTION
The registry value `0x00000000000c2e074ec69a0dfb2997ba6c7d2e1e` provided by the resolution service is not the smart contract address expected by OpenSea. Update the config to use the expected smart contract address `0x57f1887a8bf19b14fc0df6fd9b2acc9af147ea85` for ENS domains.