### PR TITLE
Basic landing page

### DIFF
--- a/packages/ui-components/src/actions/domainProfileActions.ts
+++ b/packages/ui-components/src/actions/domainProfileActions.ts
@@ -137,7 +137,7 @@ export const searchProfiles = async (
   query: string,
 ): Promise<SerializedProfileSearch[]> => {
   const data = await fetchApi(
-    `/search?name=${query}&include-suggestions=true`,
+    `/search?name=${query}&include-suggestions=true&profile-required=false&reverse-resolution-required=false`,
     {
       host: config.PROFILE.HOST_URL,
     },

--- a/packages/ui-components/src/actions/domainProfileActions.ts
+++ b/packages/ui-components/src/actions/domainProfileActions.ts
@@ -11,6 +11,7 @@ import type {
   ImageData,
   SerializedBulkDomainResponse,
   SerializedFollowerListData,
+  SerializedProfileSearch,
   SerializedPublicDomainProfileData,
   SerializedUserDomainProfileData,
 } from '../lib/types/domain';
@@ -132,14 +133,16 @@ export const getProfileUserData = async (
   });
 };
 
-export const searchProfiles = async (query: string): Promise<string[]> => {
-  const data: Array<{name: string}> | undefined = await fetchApi(
-    `/search?name=${query}`,
+export const searchProfiles = async (
+  query: string,
+): Promise<SerializedProfileSearch[]> => {
+  const data = await fetchApi(
+    `/search?name=${query}&include-suggestions=true`,
     {
       host: config.PROFILE.HOST_URL,
     },
   );
-  return data ? data.map(profile => profile.name) : [];
+  return data ? data : [];
 };
 
 export const setProfileUserData = async (

--- a/packages/ui-components/src/components/Header/ProfileSearchBar.tsx
+++ b/packages/ui-components/src/components/Header/ProfileSearchBar.tsx
@@ -3,6 +3,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import SearchIcon from '@mui/icons-material/Search';
 import ShoppingCartOutlinedIcon from '@mui/icons-material/ShoppingCartOutlined';
 import Box from '@mui/material/Box';
+import CircularProgress from '@mui/material/CircularProgress';
 import IconButton from '@mui/material/IconButton';
 import InputBase from '@mui/material/InputBase';
 import Tooltip from '@mui/material/Tooltip';
@@ -150,6 +151,15 @@ const useStyles = makeStyles<{
     width: 24,
     height: 24,
   },
+  loadingIcon: {
+    color:
+      variant === 'homepage'
+        ? theme.palette.common.white
+        : focus
+        ? theme.palette.common.black
+        : theme.palette.common.white,
+    padding: theme.spacing(1),
+  },
   rightIcon: {
     color: theme.palette.neutralShades[400],
   },
@@ -195,6 +205,7 @@ const ProfileSearchBar: React.FC<ProfileSearchBarProps> = ({
   const [t] = useTranslationContext();
   const [focus, setFocus] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
+  const [isSearching, setIsSearching] = useState(false);
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const searchBarRef = useRef<HTMLDivElement | null>(null);
   const searchResultsRef = useRef<HTMLDivElement | null>(null);
@@ -238,7 +249,9 @@ const ProfileSearchBar: React.FC<ProfileSearchBarProps> = ({
       setSearchResults([]);
       return;
     }
+    setIsSearching(true);
     const domains = await searchProfiles(searchValue);
+    setIsSearching(false);
     setSearchResults(domains);
   };
 
@@ -349,7 +362,11 @@ const ProfileSearchBar: React.FC<ProfileSearchBarProps> = ({
               className={classes.searchIconContainer}
               onClick={handleSearchIconClicked}
             >
-              <SearchIcon className={classes.searchIcon} />
+              {isSearching ? (
+                <CircularProgress className={classes.loadingIcon} />
+              ) : (
+                <SearchIcon className={classes.searchIcon} />
+              )}
             </Box>
           </Box>
         }

--- a/packages/ui-components/src/components/Header/ProfileSearchBar.tsx
+++ b/packages/ui-components/src/components/Header/ProfileSearchBar.tsx
@@ -23,6 +23,7 @@ const useStyles = makeStyles<{
   variant: ProfileSearchBarVariant;
 }>()((theme: Theme, {focus, variant}) => ({
   container: {
+    position: 'relative',
     display: 'flex',
     width: '100%',
     height: variant === 'homepage' ? '60px' : '40px',
@@ -87,19 +88,16 @@ const useStyles = makeStyles<{
     width: '16px',
   },
   searchResultsContainer: {
-    width: variant === 'homepage' ? '650px' : '512px',
+    width: '100%',
     backgroundColor: theme.palette.white,
     border: `1px solid ${theme.palette.neutralShades[100]}`,
     display: 'flex',
     flexDirection: 'column',
     borderRadius: 10,
     position: 'absolute',
-    marginTop: variant === 'homepage' ? theme.spacing(10) : theme.spacing(6),
+    marginTop: variant === 'homepage' ? theme.spacing(9) : theme.spacing(6),
     paddingTop: theme.spacing(1),
     paddingBottom: theme.spacing(1),
-    [theme.breakpoints.down('md')]: {
-      width: '100%',
-    },
   },
   searchResultsTitle: {
     fontSize: 14,
@@ -113,10 +111,9 @@ const useStyles = makeStyles<{
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'space-between',
-    width: '100%',
     cursor: 'pointer',
     '&:hover': {
-      backgroundColor: theme.palette.neutralShades[100],
+      backgroundColor: theme.palette.neutralShades[50],
     },
     '&:not(:last-child)': {
       borderBottom: `1px dashed ${theme.palette.neutralShades[100]}`,
@@ -130,7 +127,6 @@ const useStyles = makeStyles<{
   },
   searchResultLeft: {
     display: 'flex',
-    width: '100%',
     alignItems: 'center',
   },
   closeIcon: {
@@ -142,16 +138,18 @@ const useStyles = makeStyles<{
   searchIcon: {
     color:
       variant === 'homepage'
-        ? theme.palette.neutralShades[400]
-        : theme.palette.white,
+        ? theme.palette.common.white
+        : focus
+        ? theme.palette.common.black
+        : theme.palette.common.white,
+    margin: theme.spacing(1),
     width: 24,
     height: 24,
-    margin: theme.spacing(1),
   },
   rightIcon: {
     color: theme.palette.neutralShades[400],
   },
-  searchRightBox: {
+  adornmentContainer: {
     display: 'flex',
     height: '100%',
     alignItems: 'center',
@@ -160,19 +158,17 @@ const useStyles = makeStyles<{
     display: 'flex',
     alignItems: 'center',
     backgroundColor:
-      variant === 'homepage' ? theme.palette.primary.main : theme.palette.white,
+      variant === 'homepage'
+        ? theme.palette.primary.main
+        : focus
+        ? theme.palette.white
+        : undefined,
     height: '100%',
     borderRadius: '0px 7px 7px 0px',
     cursor: 'pointer',
-  },
-  searchIconDark: {
-    color:
-      variant === 'homepage'
-        ? theme.palette.common.white
-        : theme.palette.common.black,
-    margin: theme.spacing(1),
-    width: 24,
-    height: 24,
+    width: variant === 'homepage' ? '60px' : '40px',
+    marginLeft: theme.spacing(1),
+    justifyContent: 'center',
   },
 }));
 
@@ -267,10 +263,8 @@ const ProfileSearchBar: React.FC<ProfileSearchBarProps> = ({
         onChange={handleSearchChange}
         onFocus={handleComponentOnFocus}
         endAdornment={
-          !searchTerm ? (
-            <SearchIcon className={classes.searchIcon} />
-          ) : (
-            <div className={classes.searchRightBox}>
+          <Box className={classes.adornmentContainer}>
+            {searchTerm && (
               <Tooltip placement="bottom" title={t('search.clear')}>
                 <IconButton
                   data-testid="headerSearchBarClearButton"
@@ -280,16 +274,16 @@ const ProfileSearchBar: React.FC<ProfileSearchBarProps> = ({
                   <CloseIcon className={classes.closeIcon} />
                 </IconButton>
               </Tooltip>
-              <div className={classes.searchIconContainer}>
-                <SearchIcon className={classes.searchIconDark} />
-              </div>
-            </div>
-          )
+            )}
+            <Box className={classes.searchIconContainer}>
+              <SearchIcon className={classes.searchIcon} />
+            </Box>
+          </Box>
         }
       />
 
       {focus && searchTerm && searchResults.length ? (
-        <div className={classes.searchResultsContainer} ref={searchResultsRef}>
+        <Box className={classes.searchResultsContainer} ref={searchResultsRef}>
           <Typography className={classes.searchResultsTitle}>
             {t('search.searchResultsFor', {searchTerm})}
           </Typography>
@@ -299,8 +293,8 @@ const ProfileSearchBar: React.FC<ProfileSearchBarProps> = ({
               setFocus(false);
             };
             return (
-              <div className={classes.searchResult} onClick={handleClick}>
-                <div className={classes.searchResultLeft}>
+              <Box className={classes.searchResult} onClick={handleClick}>
+                <Box className={classes.searchResultLeft}>
                   <DomainPreview
                     domain={domain}
                     size={40}
@@ -309,12 +303,12 @@ const ProfileSearchBar: React.FC<ProfileSearchBarProps> = ({
                   <Typography className={classes.searchResultText}>
                     {domain}
                   </Typography>
-                </div>
+                </Box>
                 <ChevronRightOutlinedIcon className={classes.rightIcon} />
-              </div>
+              </Box>
             );
           })}
-        </div>
+        </Box>
       ) : null}
     </Box>
   );

--- a/packages/ui-components/src/components/Header/ProfileSearchBar.tsx
+++ b/packages/ui-components/src/components/Header/ProfileSearchBar.tsx
@@ -1,6 +1,7 @@
 import ChevronRightOutlinedIcon from '@mui/icons-material/ChevronRightOutlined';
 import CloseIcon from '@mui/icons-material/Close';
 import SearchIcon from '@mui/icons-material/Search';
+import ShoppingCartOutlinedIcon from '@mui/icons-material/ShoppingCartOutlined';
 import Box from '@mui/material/Box';
 import IconButton from '@mui/material/IconButton';
 import InputBase from '@mui/material/InputBase';
@@ -10,11 +11,11 @@ import type {Theme} from '@mui/material/styles';
 import {useRouter} from 'next/router';
 import React, {useEffect, useRef, useState} from 'react';
 
-import config from '@unstoppabledomains/config';
 import {makeStyles} from '@unstoppabledomains/ui-kit/styles';
 
 import {searchProfiles} from '../../actions/domainProfileActions';
 import {DomainPreview} from '../../components/Domain/DomainPreview';
+import {convertCentToUsdString, type SerializedProfileSearch} from '../../lib';
 import useTranslationContext from '../../lib/i18n';
 import type {Web3Dependencies} from '../../lib/types/web3';
 
@@ -124,6 +125,7 @@ const useStyles = makeStyles<{
     wordBreak: 'break-all',
     maxWidth: 'calc(100% - 60px)',
     marginLeft: theme.spacing(2),
+    whiteSpace: 'nowrap',
   },
   searchResultLeft: {
     display: 'flex',
@@ -189,7 +191,9 @@ const ProfileSearchBar: React.FC<ProfileSearchBarProps> = ({
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const searchBarRef = useRef<HTMLDivElement | null>(null);
   const searchResultsRef = useRef<HTMLDivElement | null>(null);
-  const [searchResults, setSearchResults] = useState<string[]>([]);
+  const [searchResults, setSearchResults] = useState<SerializedProfileSearch[]>(
+    [],
+  );
   const {classes} = useStyles({focus, variant});
   const router = useRouter();
 
@@ -287,23 +291,32 @@ const ProfileSearchBar: React.FC<ProfileSearchBarProps> = ({
           <Typography className={classes.searchResultsTitle}>
             {t('search.searchResultsFor', {searchTerm})}
           </Typography>
-          {searchResults.map(domain => {
+          {searchResults.map(searchResult => {
             const handleClick = () => {
-              void router.push(`${config.UD_ME_BASE_URL}/${domain}`);
+              void router.push(searchResult.linkUrl);
               setFocus(false);
             };
             return (
               <Box className={classes.searchResult} onClick={handleClick}>
-                <Box className={classes.searchResultLeft}>
-                  <DomainPreview
-                    domain={domain}
-                    size={40}
-                    setWeb3Deps={setWeb3Deps}
-                  />
-                  <Typography className={classes.searchResultText}>
-                    {domain}
-                  </Typography>
-                </Box>
+                {searchResult.market ? (
+                  <Box className={classes.searchResultLeft}>
+                    <ShoppingCartOutlinedIcon color="primary" />
+                    <Typography className={classes.searchResultText}>
+                      {searchResult.name} ({convertCentToUsdString(searchResult.market.price)})
+                    </Typography>
+                  </Box>
+                ) : (
+                  <Box className={classes.searchResultLeft}>
+                    <DomainPreview
+                      domain={searchResult.name}
+                      size={40}
+                      setWeb3Deps={setWeb3Deps}
+                    />
+                    <Typography className={classes.searchResultText}>
+                      {searchResult.name}
+                    </Typography>
+                  </Box>
+                )}
                 <ChevronRightOutlinedIcon className={classes.rightIcon} />
               </Box>
             );

--- a/packages/ui-components/src/components/Header/ProfileSearchBar.tsx
+++ b/packages/ui-components/src/components/Header/ProfileSearchBar.tsx
@@ -18,30 +18,53 @@ import {DomainPreview} from '../../components/Domain/DomainPreview';
 import useTranslationContext from '../../lib/i18n';
 import type {Web3Dependencies} from '../../lib/types/web3';
 
-const useStyles = makeStyles<{focus: boolean}>()((theme: Theme, {focus}) => ({
+const useStyles = makeStyles<{
+  focus: boolean;
+  variant: ProfileSearchBarVariant;
+}>()((theme: Theme, {focus, variant}) => ({
   container: {
     display: 'flex',
     width: '100%',
-    height: '40px',
+    height: variant === 'homepage' ? '60px' : '40px',
   },
   inputBase: {
     border: `1px solid ${
-      focus ? 'rgba(255, 255, 255, 0.50)' : 'rgba(255, 255, 255, 0.10)'
+      variant === 'homepage'
+        ? theme.palette.neutralShades[400]
+        : focus
+        ? 'rgba(255, 255, 255, 0.50)'
+        : 'rgba(255, 255, 255, 0.10)'
     }`,
     borderRadius: theme.shape.borderRadius,
-    paddingLeft: 12,
+    paddingLeft: variant === 'homepage' ? theme.spacing(2) : theme.spacing(1),
     backdropFilter: 'blur(5px)',
-    backgroundColor: 'rgba(255, 255, 255, 0.20)',
+    backgroundColor:
+      variant === 'homepage' ? 'white' : 'rgba(255, 255, 255, 0.20)',
+    boxShadow: variant === 'homepage' ? theme.shadows[6] : undefined,
   },
   input: {
-    fontSize: 16,
-    color: theme.palette.common.white,
+    fontSize: variant === 'homepage' ? 20 : 16,
+    color:
+      variant === 'homepage'
+        ? focus
+          ? theme.palette.common.black
+          : theme.palette.neutralShades[400]
+        : theme.palette.common.white,
     '&::-webkit-search-cancel-button': {
       WebkitAppearance: 'none',
     },
-    '&::placeholder': {color: theme.palette.common.white, opacity: 1},
+    '&::placeholder': {
+      color:
+        variant === 'homepage'
+          ? theme.palette.neutralShades[400]
+          : theme.palette.common.white,
+      opacity: 1,
+    },
     '&::-webkit-input-placeholder': {
-      color: theme.palette.common.white,
+      color:
+        variant === 'homepage'
+          ? theme.palette.neutralShades[400]
+          : theme.palette.common.white,
       opacity: 1,
     },
   },
@@ -64,18 +87,18 @@ const useStyles = makeStyles<{focus: boolean}>()((theme: Theme, {focus}) => ({
     width: '16px',
   },
   searchResultsContainer: {
-    width: '512px',
+    width: variant === 'homepage' ? '650px' : '512px',
     backgroundColor: theme.palette.white,
     border: `1px solid ${theme.palette.neutralShades[100]}`,
     display: 'flex',
     flexDirection: 'column',
     borderRadius: 10,
     position: 'absolute',
-    marginTop: theme.spacing(6),
+    marginTop: variant === 'homepage' ? theme.spacing(10) : theme.spacing(6),
     paddingTop: theme.spacing(1),
     paddingBottom: theme.spacing(1),
     [theme.breakpoints.down('md')]: {
-      width: '350px',
+      width: '100%',
     },
   },
   searchResultsTitle: {
@@ -111,12 +134,16 @@ const useStyles = makeStyles<{focus: boolean}>()((theme: Theme, {focus}) => ({
     alignItems: 'center',
   },
   closeIcon: {
-    color: '#FFFFFF80',
+    color:
+      variant === 'homepage' ? theme.palette.neutralShades[400] : '#FFFFFF80',
     height: '16px',
     width: '16px',
   },
   searchIcon: {
-    color: theme.palette.common.white,
+    color:
+      variant === 'homepage'
+        ? theme.palette.neutralShades[400]
+        : theme.palette.white,
     width: 24,
     height: 24,
     margin: theme.spacing(1),
@@ -130,23 +157,36 @@ const useStyles = makeStyles<{focus: boolean}>()((theme: Theme, {focus}) => ({
     alignItems: 'center',
   },
   searchIconContainer: {
-    backgroundColor: 'white',
+    display: 'flex',
+    alignItems: 'center',
+    backgroundColor:
+      variant === 'homepage' ? theme.palette.primary.main : theme.palette.white,
     height: '100%',
     borderRadius: '0px 7px 7px 0px',
+    cursor: 'pointer',
   },
   searchIconDark: {
-    color: theme.palette.common.black,
+    color:
+      variant === 'homepage'
+        ? theme.palette.common.white
+        : theme.palette.common.black,
     margin: theme.spacing(1),
     width: 24,
     height: 24,
   },
 }));
 
+type ProfileSearchBarVariant = 'header' | 'homepage';
+
 type ProfileSearchBarProps = {
   setWeb3Deps?: (value: Web3Dependencies | undefined) => void;
+  variant?: ProfileSearchBarVariant;
 };
 
-const ProfileSearchBar: React.FC<ProfileSearchBarProps> = ({setWeb3Deps}) => {
+const ProfileSearchBar: React.FC<ProfileSearchBarProps> = ({
+  setWeb3Deps,
+  variant = 'header',
+}) => {
   const [t] = useTranslationContext();
   const [focus, setFocus] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
@@ -154,7 +194,7 @@ const ProfileSearchBar: React.FC<ProfileSearchBarProps> = ({setWeb3Deps}) => {
   const searchBarRef = useRef<HTMLDivElement | null>(null);
   const searchResultsRef = useRef<HTMLDivElement | null>(null);
   const [searchResults, setSearchResults] = useState<string[]>([]);
-  const {classes} = useStyles({focus});
+  const {classes} = useStyles({focus, variant});
   const router = useRouter();
 
   useEffect(() => {

--- a/packages/ui-components/src/components/Image/Logo.tsx
+++ b/packages/ui-components/src/components/Image/Logo.tsx
@@ -27,21 +27,21 @@ const useStyles = makeStyles()(() => ({
 type LogoProps = {
   className?: string;
   inverse?: boolean;
-  absoluteUrl?: boolean;
+  url?: string;
 };
 
 type HomeLinkProps = {
   children: React.ReactNode;
 };
 
-const Logo: React.FC<LogoProps> = ({className = '', inverse, absoluteUrl}) => {
+const Logo: React.FC<LogoProps> = ({className = '', inverse, url}) => {
   const {classes, cx} = useStyles();
   const logoIconTheme = inverse ? LogoTheme.White : LogoTheme.Primary;
 
   const HomeLink: React.FC<HomeLinkProps> = ({children}) => {
     return (
       <Link
-        href={config.UNSTOPPABLE_WEBSITE_URL}
+        href={url || config.UNSTOPPABLE_WEBSITE_URL}
         className={classes.homeLink}
         aria-label="home page"
       >

--- a/packages/ui-components/src/lib/domain/format.ts
+++ b/packages/ui-components/src/lib/domain/format.ts
@@ -4,6 +4,40 @@ import {
   MANAGEABLE_DOMAIN_LABEL,
 } from '../../lib/types/domain';
 
+export const convertCentToDollar = (cent: number): number => {
+  return cent / 100;
+};
+
+const getUsdNumberFormat = (showCents: boolean) => {
+  const locales: string[] = ['en-US'];
+  return new Intl.NumberFormat(
+    // Prefer browser's locale, fallback on en-US
+    locales.filter(x => Boolean(x)),
+    {
+      style: 'currency',
+      currency: 'USD',
+      // to hide cents, set the max fraction digits to zero
+      maximumFractionDigits: showCents ? 2 : 0,
+      minimumFractionDigits: showCents ? 2 : 0,
+    },
+  );
+};
+
+export const convertCentToUsdString = (
+  cent: number,
+  alwaysShowCents: boolean = false,
+): string => {
+  const dollars = convertCentToDollar(cent);
+  const cents = Math.abs(cent) % 100;
+
+  const formatter = getUsdNumberFormat(cents > 0 || alwaysShowCents);
+
+  // NOTE: for locales that result in whitespace in the formatted output
+  // the formatted string output uses NBSP (non-breaking space) characters (char code 160)
+  // rather than normal space characters (char code 32)
+  return formatter.format(dollars);
+};
+
 const isDomainFormatValid = (
   domain: string,
   labelValidationRegex: RegExp,

--- a/packages/ui-components/src/lib/seo.ts
+++ b/packages/ui-components/src/lib/seo.ts
@@ -35,7 +35,7 @@ export const getSeoTags = (props: GetSeoTagsProps): NextSeoProps => {
 
   seoTags.openGraph.images = [{url: imageUrl}];
   seoTags.twitter = {cardType: 'summary'};
-  if (props.socialsInfo[DomainProfileSocialMedia.Twitter]?.screenName) {
+  if (props.socialsInfo?.[DomainProfileSocialMedia.Twitter]?.screenName) {
     seoTags.twitter.site = `@${UD_TWITTER_HANDLE}`;
     seoTags.twitter.handle = `@${
       props.socialsInfo[DomainProfileSocialMedia.Twitter]?.screenName

--- a/packages/ui-components/src/lib/types/domain.ts
+++ b/packages/ui-components/src/lib/types/domain.ts
@@ -46,6 +46,13 @@ export type DiscordUserInfo = {
   userName: string;
 } | null;
 
+export type DomainCryptoVerificationBodyPOST = {
+  symbol: string;
+  address: string;
+  plaintextMessage: string;
+  signedMessage: string;
+};
+
 export type DomainDescription = {
   name: string;
   label: string;
@@ -64,13 +71,6 @@ export enum DomainFieldTypes {
   ReferralTier = 'referralTier',
   WebacyScore = 'webacyScore',
 }
-
-export type DomainCryptoVerificationBodyPOST = {
-  symbol: string;
-  address: string;
-  plaintextMessage: string;
-  signedMessage: string;
-};
 
 export enum DomainProfileKeys {
   AuthAddress = 'authAddress',
@@ -262,6 +262,18 @@ export type SerializedFollowerListData = {
   };
   relationship_type: 'following' | 'followers';
   domain: string;
+};
+
+export type SerializedProfileSearch = {
+  name: string;
+  imagePath: string;
+  imageType: string;
+  ownerAddress: string;
+  linkUrl: string;
+  market?: {
+    price: number;
+    location: 'primary' | 'secondary';
+  };
 };
 
 export type SerializedPublicDomainProfileData = {

--- a/packages/ui-components/src/lib/types/seo.ts
+++ b/packages/ui-components/src/lib/types/seo.ts
@@ -6,10 +6,10 @@ import type {
 export const DEFAULT_SEO_DESCRIPTION =
   'Domain profiles give holders a way to associate extra pieces of metadata with their domains.';
 export type GetSeoTagsProps = {
-  domain: string;
+  domain?: string;
   title: string;
-  profileData: SerializedPublicDomainProfileData | null | undefined;
-  socialsInfo: SerializedDomainProfileSocialAccountsUserInfo;
+  profileData?: SerializedPublicDomainProfileData | null | undefined;
+  socialsInfo?: SerializedDomainProfileSocialAccountsUserInfo;
   domainAvatar?: string | null;
 };
 

--- a/packages/ui-components/src/locales/en.json
+++ b/packages/ui-components/src/locales/en.json
@@ -599,7 +599,7 @@
   },
   "search": {
     "clear": "Clear",
-    "searchProfiles": "Search profiles",
+    "searchProfiles": "Find a profile",
     "searchResultsFor": "Search results for \"{{searchTerm}}\""
   },
   "upsell": {

--- a/packages/ui-components/src/locales/en.json
+++ b/packages/ui-components/src/locales/en.json
@@ -599,8 +599,9 @@
   },
   "search": {
     "clear": "Clear",
-    "searchProfiles": "Find a profile",
-    "searchResultsFor": "Search results for \"{{searchTerm}}\""
+    "searchProfiles": "Enter a name or address",
+    "searchResultsFor": "Profiles matching \"{{searchTerm}}\"",
+    "availableDomainsFor": "Available for purchase matching \"{{searchTerm}}\""
   },
   "upsell": {
     "udBlueSubscription": {
@@ -622,5 +623,10 @@
     "riskScoreDescription": "Webacy analysis indicates a Safety Score to measure risk when interacting with the account owning this domain.",
     "share": "Share your Webacy Safety Score on X",
     "shareMessage": "Check out my Safety Score powered by @unstoppableweb and @mywebacy on my UD profile #safetyscore #walletrisk"
+  },
+  "footer": {
+    "copyright":"© Unstoppable Domains Inc. All Rights Reserved.",
+    "terms": "Terms",
+    "privacyPolicy":"Privacy Policy"
   }
 }

--- a/server/next.config.js
+++ b/server/next.config.js
@@ -136,11 +136,16 @@ const nextConfig = {
       // Headers for homepage
       ...['/'].map(source => ({
         source,
-        headers: fastlyCacheHeaders({
-          staleIfError: 86400, // 1 day
-          staleWhileRevalidate: 86400, // 1 day
-          ttl: 3600, // 1 hour
-        }),
+        headers: [
+          ...fastlyCacheHeaders({
+            ttl: 86400, // 1 day
+          }),
+          {
+            key: 'Content-Security-Policy',
+            value:
+              'connect-src * data: blob:; img-src * data: blob:; object-src *',
+          },
+        ],
       })),
       // Headers for domain profile
       {

--- a/server/pages/[domain]/index.page.tsx
+++ b/server/pages/[domain]/index.page.tsx
@@ -830,9 +830,7 @@ const DomainProfile = ({
                 {profileData?.webacy && (
                   <Box className={classes.riskScoreContainer}>
                     <Avatar
-                      src={
-                        'https://storage.googleapis.com/unstoppable-client-assets/images/webacy/logo.png'
-                      }
+                      src={`${config.ASSETS_BUCKET_URL}/images/webacy/logo.png`}
                       className={classes.riskScoreLogo}
                       onClick={() =>
                         window.open(

--- a/server/pages/[domain]/index.page.tsx
+++ b/server/pages/[domain]/index.page.tsx
@@ -536,7 +536,7 @@ const DomainProfile = ({
             : undefined
         }
       >
-        <Logo className={classes.logo} inverse absoluteUrl />
+        <Logo className={classes.logo} url={config.UD_ME_BASE_URL} inverse />
         <div className={classes.head}>
           {isOwner !== undefined && (
             <div className={classes.menuButtonContainer}>

--- a/server/pages/_document.page.tsx
+++ b/server/pages/_document.page.tsx
@@ -1,6 +1,7 @@
 import Document, {Head, Html, Main, NextScript} from 'next/document';
 import React from 'react';
 
+import config from '@unstoppabledomains/config';
 import {getImageUrl, withEmotionCache} from '@unstoppabledomains/ui-components';
 import theme from '@unstoppabledomains/ui-kit/styles';
 
@@ -12,6 +13,28 @@ class MyDocument extends Document {
     return (
       <Html>
         <Head>
+          {/*
+            Preconnect allows the browser to setup early connections before an HTTP request
+            is actually sent to the server.
+            This includes DNS lookups, TLS negotiations, TCP handshakes.
+          */}
+          <link
+            rel="preconnect"
+            href={config.ASSETS_BUCKET_URL}
+            crossOrigin="anonymous"
+          />
+          <link
+            rel="preload"
+            as="font"
+            href={`${config.ASSETS_BUCKET_URL}/fonts/HelveticaNeueLT97BlackCondensed.ttf`}
+            crossOrigin="anonymous"
+          />
+          <link
+            rel="preload"
+            as="font"
+            href={`${config.ASSETS_BUCKET_URL}/fonts/Inter.woff2`}
+            crossOrigin="anonymous"
+          />
           {/* Legacy favicon without transparent pixels, to fix transparency issues */}
           <link rel="icon" href={shortcutIcon} sizes="any" />
           {/* Responsive, future-proof SVG favicon, supports dark/light themes */}

--- a/server/pages/index.page.tsx
+++ b/server/pages/index.page.tsx
@@ -4,7 +4,9 @@ import Typography from '@mui/material/Typography';
 import {NextSeo} from 'next-seo';
 import React from 'react';
 import {useStyles} from 'styles/pages/index.styles';
+import {GlobalStyles} from 'tss-react';
 
+import config from '@unstoppabledomains/config';
 import {
   ProfileSearchBar,
   getSeoTags,
@@ -12,10 +14,27 @@ import {
   useWeb3Context,
 } from '@unstoppabledomains/ui-components';
 
+export const nftCardsArray = [
+  `${config.ASSETS_BUCKET_URL}/images/landing/new/nft_pfp_card_3.webp`,
+  `${config.ASSETS_BUCKET_URL}/images/landing/new/nft_pfp_card_4.webp`,
+];
+
+const getRandomNftCards = (arr: string[]) => {
+  const firstNFTCard = arr[Math.floor(Math.random() * arr.length)];
+  const filteredNftCardsArray = arr.filter(card => card !== firstNFTCard);
+  const secondNFTCard =
+    filteredNftCardsArray[
+      Math.floor(Math.random() * filteredNftCardsArray.length)
+    ];
+
+  return [firstNFTCard, secondNFTCard];
+};
+
 const HomePage = () => {
-  const {classes, cx} = useStyles();
+  const {classes, cx} = useStyles({});
   const {setWeb3Deps} = useWeb3Context();
   const [t] = useTranslationContext();
+  const [firstNFTCard, secondNFTCard] = getRandomNftCards(nftCardsArray);
 
   const seoTags = getSeoTags({
     title: t('nftCollection.unstoppableDomains'),
@@ -24,17 +43,35 @@ const HomePage = () => {
   return (
     <Box className={classes.container}>
       <NextSeo {...seoTags} />
+      <GlobalStyles
+        styles={{
+          '@font-face': {
+            fontFamily: 'Helvetica Neue',
+            src: `url('${config.ASSETS_BUCKET_URL}/fonts/HelveticaNeueLT97BlackCondensed.ttf') format('truetype')`,
+            fontWeight: 900,
+            fontStyle: 'normal',
+            fontDisplay: 'swap',
+          },
+        }}
+      />
       <Grid
         container
         className={classes.content}
         data-testid="mainContentContainer"
       >
         <Grid item xs={12} className={classes.item}>
-          <img
-            width={280}
-            height={200}
-            src="https://storage.googleapis.com/unstoppable-client-assets/images/homepage/how-mint.svg"
-          />
+          <Box className={classes.rightBlock}>
+            <img
+              src={firstNFTCard}
+              alt="nft-card-1"
+              className={cx(classes.cardImage, classes.cardImageTop)}
+            />
+            <img
+              src={secondNFTCard}
+              alt="nft-card-2"
+              className={cx(classes.cardImage, classes.cardImageBottom)}
+            />
+          </Box>
         </Grid>
         <Grid item xs={12} className={classes.item}>
           <Typography className={classes.sectionTitle}>

--- a/server/pages/index.page.tsx
+++ b/server/pages/index.page.tsx
@@ -89,6 +89,29 @@ const HomePage = () => {
           </Box>
         </Grid>
       </Grid>
+      <Box className={classes.footerContainer}>
+        <Box className={classes.footerContent}>
+          <Typography className={classes.copyright} variant="body2">
+            {t('footer.copyright')}
+          </Typography>
+        </Box>
+        <Box className={classes.footerContent}>
+          <Typography variant="caption">
+            <a
+              className={classes.footerLink}
+              href="https://unstoppabledomains.com/terms"
+            >
+              {t('footer.terms')}
+            </a>
+            <a
+              className={classes.footerLink}
+              href="https://unstoppabledomains.com/privacy-policy"
+            >
+              {t('footer.privacyPolicy')}
+            </a>
+          </Typography>
+        </Box>
+      </Box>
     </Box>
   );
 };

--- a/server/pages/index.page.tsx
+++ b/server/pages/index.page.tsx
@@ -1,17 +1,59 @@
-import React, {useEffect} from 'react';
+import Box from '@mui/material/Box';
+import Grid from '@mui/material/Grid';
+import Typography from '@mui/material/Typography';
+import {NextSeo} from 'next-seo';
+import React from 'react';
+import {useStyles} from 'styles/pages/index.styles';
 
-import config from '@unstoppabledomains/config';
+import {
+  ProfileSearchBar,
+  getSeoTags,
+  useTranslationContext,
+  useWeb3Context,
+} from '@unstoppabledomains/ui-components';
 
 const HomePage = () => {
-  // redirect to the Unstoppable Domains homepage until a UD.me specific
-  // landing page is created
-  useEffect(() => {
-    if (!window.location.href.includes(config.UNSTOPPABLE_WEBSITE_URL)) {
-      window.location.href = config.UNSTOPPABLE_WEBSITE_URL;
-    }
-  }, []);
+  const {classes, cx} = useStyles();
+  const {setWeb3Deps} = useWeb3Context();
+  const [t] = useTranslationContext();
 
-  return <div></div>;
+  const seoTags = getSeoTags({
+    title: t('nftCollection.unstoppableDomains'),
+  });
+
+  return (
+    <Box className={classes.container}>
+      <NextSeo {...seoTags} />
+      <Grid
+        container
+        className={classes.content}
+        data-testid="mainContentContainer"
+      >
+        <Grid item xs={12} className={classes.item}>
+          <img
+            width={280}
+            height={200}
+            src="https://storage.googleapis.com/unstoppable-client-assets/images/homepage/how-mint.svg"
+          />
+        </Grid>
+        <Grid item xs={12} className={classes.item}>
+          <Typography className={classes.sectionTitle}>
+            Unstoppable Profiles
+          </Typography>
+        </Grid>
+        <Grid item xs={12} className={classes.item}>
+          <Typography className={classes.sectionSubTitle}>
+            Own your identity in the digital world.
+          </Typography>
+        </Grid>
+        <Grid item xs={12} className={classes.item}>
+          <Box className={classes.searchContainer}>
+            <ProfileSearchBar variant="homepage" setWeb3Deps={setWeb3Deps} />
+          </Box>
+        </Grid>
+      </Grid>
+    </Box>
+  );
 };
 
 export default HomePage;

--- a/server/styles/pages/index.styles.ts
+++ b/server/styles/pages/index.styles.ts
@@ -11,6 +11,7 @@ export const useStyles = makeStyles<
   'cardImageBottom' | 'cardImageTop'
 >()((theme: Theme, {isSaleActive}, classes) => ({
   container: {
+    position: 'relative',
     background: theme.palette.neutralShades[100],
     display: 'flex',
     flexDirection: 'column',
@@ -67,15 +68,15 @@ export const useStyles = makeStyles<
     width: '100%',
     paddingTop: theme.spacing(2.5),
     zIndex: 1,
-    maxWidth: 245,
-    minHeight: 250,
-    marginBottom: theme.spacing(12),
+    maxWidth: 175,
+    minHeight: 180,
+    marginBottom: theme.spacing(8),
     transition: theme.transitions.create([
       'min-height, max-width, padding-top',
     ]),
     [theme.breakpoints.down('lg')]: {
-      maxWidth: 245,
-      minHeight: 250,
+      maxWidth: 175,
+      minHeight: 180,
     },
     [theme.breakpoints.down('md')]: {
       maxWidth: 166,
@@ -104,7 +105,7 @@ export const useStyles = makeStyles<
   cardImage: {
     display: 'flex',
     width: '100%',
-    maxWidth: 215,
+    maxWidth: 150,
     borderRadius: 16,
     boxShadow:
       '0px 2px 3px rgba(0, 0, 0, 0.07), 0px 6px 6px rgba(0, 0, 0, 0.04), 0px 12px 12px rgba(0, 0, 0, 0.03), 0px 20px 24px rgba(0, 0, 0, 0.03), 0px 32px 40px rgba(0, 0, 0, 0.02), 0px 80px 100px rgba(0, 0, 0, 0.16), 0px 0px 4px rgba(0, 0, 0, 0.08), 0px 8px 48px rgba(0, 0, 0, 0.08)',
@@ -118,7 +119,7 @@ export const useStyles = makeStyles<
       },
     ),
     [theme.breakpoints.down('lg')]: {
-      maxWidth: 215,
+      maxWidth: 150,
     },
     [theme.breakpoints.down('md')]: {
       maxWidth: 132,
@@ -146,9 +147,30 @@ export const useStyles = makeStyles<
       right: 0,
     },
   },
-  footer: {
+  footerContainer: {
     ...theme.containers.main,
     maxWidth: 1256,
-    padding: theme.spacing(0, 2.5),
+    padding: theme.spacing(2),
+    position: 'absolute',
+    bottom: 0,
+    display: 'flex',
+    flexDirection: 'column',
+  },
+  footerContent: {
+    display: 'flex',
+    justifyContent: 'center',
+  },
+  footerLink: {
+    marginRight: theme.spacing(1),
+    fontWeight: theme.typography.fontWeightMedium,
+    color: theme.palette.neutralShades[600],
+    cursor: 'pointer',
+    wordBreak: 'normal',
+    '&:hover': {
+      textDecoration: 'underline',
+    },
+  },
+  copyright: {
+    color: theme.palette.neutralShades[600],
   },
 }));

--- a/server/styles/pages/index.styles.ts
+++ b/server/styles/pages/index.styles.ts
@@ -67,22 +67,21 @@ export const useStyles = makeStyles<
     width: '100%',
     paddingTop: theme.spacing(2.5),
     zIndex: 1,
-    maxWidth: 400,
-    minHeight: 408,
-    marginBottom: theme.spacing(15),
+    maxWidth: 245,
+    minHeight: 250,
+    marginBottom: theme.spacing(12),
     transition: theme.transitions.create([
       'min-height, max-width, padding-top',
     ]),
     [theme.breakpoints.down('lg')]: {
-      maxWidth: 304,
-      minHeight: 326,
-      marginBottom: theme.spacing(12),
+      maxWidth: 245,
+      minHeight: 250,
     },
     [theme.breakpoints.down('md')]: {
       maxWidth: 166,
       minHeight: 168,
       paddingTop: 0,
-      marginBottom: theme.spacing(9),
+      marginBottom: theme.spacing(7),
     },
     [theme.breakpoints.down('sm')]: {
       maxWidth: 150,
@@ -105,7 +104,7 @@ export const useStyles = makeStyles<
   cardImage: {
     display: 'flex',
     width: '100%',
-    maxWidth: 304,
+    maxWidth: 215,
     borderRadius: 16,
     boxShadow:
       '0px 2px 3px rgba(0, 0, 0, 0.07), 0px 6px 6px rgba(0, 0, 0, 0.04), 0px 12px 12px rgba(0, 0, 0, 0.03), 0px 20px 24px rgba(0, 0, 0, 0.03), 0px 32px 40px rgba(0, 0, 0, 0.02), 0px 80px 100px rgba(0, 0, 0, 0.16), 0px 0px 4px rgba(0, 0, 0, 0.08), 0px 8px 48px rgba(0, 0, 0, 0.08)',
@@ -119,7 +118,7 @@ export const useStyles = makeStyles<
       },
     ),
     [theme.breakpoints.down('lg')]: {
-      maxWidth: 240,
+      maxWidth: 215,
     },
     [theme.breakpoints.down('md')]: {
       maxWidth: 132,

--- a/server/styles/pages/index.styles.ts
+++ b/server/styles/pages/index.styles.ts
@@ -1,0 +1,67 @@
+import type {Theme} from '@mui/material/styles';
+
+import {makeStyles} from '@unstoppabledomains/ui-kit/styles';
+
+export const useStyles = makeStyles()((theme: Theme) => ({
+  container: {
+    background: theme.palette.neutralShades[100],
+    display: 'flex',
+    flexDirection: 'column',
+    flex: '1 1 auto',
+    paddingBottom: theme.spacing(16),
+    height: '100%',
+    justifyContent: 'center',
+  },
+  content: {
+    ...theme.containers.main,
+    paddingLeft: theme.spacing(2),
+    paddingRight: theme.spacing(2),
+  },
+  item: {
+    justifyContent: 'center',
+    display: 'flex',
+  },
+  searchContainer: {
+    display: 'flex',
+    zIndex: 102,
+    flexDirection: 'column',
+    maxWidth: '650px',
+    width: '100%',
+    [theme.breakpoints.down('md')]: {
+      width: '100%',
+    },
+  },
+  sectionTitle: {
+    fontSize: 60,
+    lineHeight: '64px',
+    fontFamily: "'Helvetica Neue', sans-serif",
+    fontWeight: 900,
+    textAlign: 'center',
+    marginTop: theme.spacing(3),
+    marginBottom: theme.spacing(7),
+    [theme.breakpoints.down('sm')]: {
+      marginBottom: theme.spacing(4),
+      fontSize: 32,
+      lineHeight: '40px',
+    },
+  },
+  sectionSubTitle: {
+    fontSize: 22,
+    lineHeight: '36px',
+    textAlign: 'center',
+    color: theme.palette.neutralShades[600],
+    marginBottom: theme.spacing(7),
+    marginTop: theme.spacing(-4),
+    [theme.breakpoints.down('sm')]: {
+      fontSize: 18,
+      lineHeight: '24px',
+      marginBottom: theme.spacing(4),
+      marginTop: theme.spacing(-2),
+    },
+  },
+  footer: {
+    ...theme.containers.main,
+    maxWidth: 1256,
+    padding: theme.spacing(0, 2.5),
+  },
+}));

--- a/server/styles/pages/index.styles.ts
+++ b/server/styles/pages/index.styles.ts
@@ -148,13 +148,13 @@ export const useStyles = makeStyles<
     },
   },
   footerContainer: {
-    ...theme.containers.main,
-    maxWidth: 1256,
     padding: theme.spacing(2),
     position: 'absolute',
     bottom: 0,
     display: 'flex',
     flexDirection: 'column',
+    width: '100%',
+    justifyContent: 'center',
   },
   footerContent: {
     display: 'flex',

--- a/server/styles/pages/index.styles.ts
+++ b/server/styles/pages/index.styles.ts
@@ -2,7 +2,14 @@ import type {Theme} from '@mui/material/styles';
 
 import {makeStyles} from '@unstoppabledomains/ui-kit/styles';
 
-export const useStyles = makeStyles()((theme: Theme) => ({
+type StyleProps = {
+  isSaleActive?: boolean;
+};
+
+export const useStyles = makeStyles<
+  StyleProps,
+  'cardImageBottom' | 'cardImageTop'
+>()((theme: Theme, {isSaleActive}, classes) => ({
   container: {
     background: theme.palette.neutralShades[100],
     display: 'flex',
@@ -27,9 +34,6 @@ export const useStyles = makeStyles()((theme: Theme) => ({
     flexDirection: 'column',
     maxWidth: '650px',
     width: '100%',
-    [theme.breakpoints.down('md')]: {
-      width: '100%',
-    },
   },
   sectionTitle: {
     fontSize: 60,
@@ -50,13 +54,97 @@ export const useStyles = makeStyles()((theme: Theme) => ({
     lineHeight: '36px',
     textAlign: 'center',
     color: theme.palette.neutralShades[600],
-    marginBottom: theme.spacing(7),
+    marginBottom: theme.spacing(4),
     marginTop: theme.spacing(-4),
     [theme.breakpoints.down('sm')]: {
       fontSize: 18,
       lineHeight: '24px',
-      marginBottom: theme.spacing(4),
       marginTop: theme.spacing(-2),
+    },
+  },
+  rightBlock: {
+    position: 'relative',
+    width: '100%',
+    paddingTop: theme.spacing(2.5),
+    zIndex: 1,
+    maxWidth: 400,
+    minHeight: 408,
+    marginBottom: theme.spacing(15),
+    transition: theme.transitions.create([
+      'min-height, max-width, padding-top',
+    ]),
+    [theme.breakpoints.down('lg')]: {
+      maxWidth: 304,
+      minHeight: 326,
+      marginBottom: theme.spacing(12),
+    },
+    [theme.breakpoints.down('md')]: {
+      maxWidth: 166,
+      minHeight: 168,
+      paddingTop: 0,
+      marginBottom: theme.spacing(9),
+    },
+    [theme.breakpoints.down('sm')]: {
+      maxWidth: 150,
+      minHeight: 153,
+      marginBottom: theme.spacing(6),
+    },
+    [`&:hover .${classes.cardImageBottom}`]: {
+      transform: 'matrix(1, 0, 0, 1, 0, 0)',
+      right: '21%',
+      bottom: 0,
+      zIndex: 0,
+    },
+    [`&:hover .${classes.cardImageTop}`]: {
+      bottom: '-21%',
+      right: '10%',
+      zIndex: -1,
+      transform: 'matrix(0.99, 0.14, -0.14, 0.99, 0, 0)',
+    },
+  },
+  cardImage: {
+    display: 'flex',
+    width: '100%',
+    maxWidth: 304,
+    borderRadius: 16,
+    boxShadow:
+      '0px 2px 3px rgba(0, 0, 0, 0.07), 0px 6px 6px rgba(0, 0, 0, 0.04), 0px 12px 12px rgba(0, 0, 0, 0.03), 0px 20px 24px rgba(0, 0, 0, 0.03), 0px 32px 40px rgba(0, 0, 0, 0.02), 0px 80px 100px rgba(0, 0, 0, 0.16), 0px 0px 4px rgba(0, 0, 0, 0.08), 0px 8px 48px rgba(0, 0, 0, 0.08)',
+    '& img': {
+      objectFit: 'cover',
+    },
+    transition: theme.transitions.create(
+      ['transform', 'right', 'bottom', 'z-index'],
+      {
+        duration: 850,
+      },
+    ),
+    [theme.breakpoints.down('lg')]: {
+      maxWidth: 240,
+    },
+    [theme.breakpoints.down('md')]: {
+      maxWidth: 132,
+    },
+    [theme.breakpoints.down('sm')]: {
+      maxWidth: 120,
+    },
+  },
+  cardImageTop: {
+    position: 'absolute',
+    bottom: 0,
+    right: '21%',
+    zIndex: 0,
+  },
+  cardImageBottom: {
+    position: 'absolute',
+    bottom: '-21%',
+    right: '10%',
+    zIndex: -1,
+    transform: 'matrix(0.99, 0.14, -0.14, 0.99, 0, 0)',
+    [theme.breakpoints.down('lg')]: {
+      right: '5%',
+    },
+    [theme.breakpoints.down('md')]: {
+      right: 0,
     },
   },
   footer: {


### PR DESCRIPTION
There has long been missing a landing page for https://ud.me, and instead has been redirecting to Unstoppable Domains homepage. This PR creates a basic landing page that can:

- Search for existing domain profiles
- Search for wallet addresses
- Suggest domains available for purchase

## Screenshots
### Default page view
<img width="991" alt="image" src="https://github.com/unstoppabledomains/domain-profiles/assets/21039114/58784aec-e34b-4510-8842-1d859fac1cfe">

### Searching for profile
<img width="988" alt="image" src="https://github.com/unstoppabledomains/domain-profiles/assets/21039114/cb3d2c5f-c3b8-4e04-9a22-a8577658c282">

### Searching for address
<img width="990" alt="image" src="https://github.com/unstoppabledomains/domain-profiles/assets/21039114/a5253bc3-3d9d-409b-aa07-b1ba5db68e92">
