### PR TITLE
Reorganize context providers nesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ import Button from '@mui/material/Button';
 import React from 'react';
 
 import {
+  BaseProvider,
   UnstoppableMessaging,
   UnstoppableMessagingProvider,
-  Web3ContextProvider,
   useUnstoppableMessaging,
 } from '@unstoppabledomains/ui-components';
 
@@ -87,12 +87,12 @@ const MyPage = () => {
   };
 
   return (
-    <Web3ContextProvider>
+    <BaseProvider>
       <UnstoppableMessagingProvider>
         <UnstoppableMessaging />
         <Button onClick={handleOpenChat}>Open chat</Button>
       </UnstoppableMessagingProvider>
-    </Web3ContextProvider>
+    </BaseProvider>
   );
 };
 

--- a/examples/unstoppable-messaging/pages/_app.page.tsx
+++ b/examples/unstoppable-messaging/pages/_app.page.tsx
@@ -5,7 +5,10 @@ import React from 'react';
 import 'react-medium-image-zoom/dist/styles.css';
 import 'swiper/css/bundle';
 
-import {UnstoppableMessagingProvider} from '@unstoppabledomains/ui-components';
+import {
+  BaseProvider,
+  UnstoppableMessagingProvider,
+} from '@unstoppabledomains/ui-components';
 
 // setup wrapped app props
 export type NextPageWithLayout = NextPage & {
@@ -31,9 +34,11 @@ const WrappedApp = (props: WrappedAppProps) => {
           content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, shrink-to-fit=no, user-scalable=0"
         />
       </Head>
-      <UnstoppableMessagingProvider>
-        <Component {...pageProps} />
-      </UnstoppableMessagingProvider>
+      <BaseProvider>
+        <UnstoppableMessagingProvider>
+          <Component {...pageProps} />
+        </UnstoppableMessagingProvider>
+      </BaseProvider>
     </>
   );
 };

--- a/packages/ui-components/CHANGELOG.md
+++ b/packages/ui-components/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.0.33
+
+- Reorganize context provider's order
+- Move `notistack` to peerDependencies
+
 ## 0.0.32
 
 - Move `react-query` to peerDependencies

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -71,7 +71,6 @@
     "next-secure-headers": "^2.2.0",
     "next-seo": "^6.1.0",
     "next-transpile-modules": "^10.0.0",
-    "notistack": "^2.0.5",
     "numeral": "^2.0.6",
     "qs": "^6.11.2",
     "ramda": "^0.27.1",
@@ -111,6 +110,7 @@
   },
   "peerDependencies": {
     "@unstoppabledomains/ui-kit": "^0.3.15",
+    "notistack": "^2.0.5",
     "react-query": "^3.39.3"
   },
   "engines": {

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unstoppabledomains/ui-components",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "private": true,
   "description": "An open and reusable suite of Unstoppable Domains management components",
   "keywords": [

--- a/packages/ui-components/src/components/Header/LoginButton.tsx
+++ b/packages/ui-components/src/components/Header/LoginButton.tsx
@@ -74,6 +74,7 @@ export const LoginButton: React.FC<LoginButtonProps> = ({
   hidden,
   isWhiteBg,
   big,
+  onLoginComplete,
   ...props
 }) => {
   const {classes, cx} = useStyles();
@@ -103,8 +104,8 @@ export const LoginButton: React.FC<LoginButtonProps> = ({
       setAccessWalletOpen(true);
       return;
     }
-    const loginResult = await loginWithAddress();
-    props.onLoginComplete(loginResult.address, loginResult.domain);
+    const {address, domain} = await loginWithAddress();
+    onLoginComplete(address, domain);
   };
 
   const handleAccessWalletComplete = async (
@@ -112,8 +113,10 @@ export const LoginButton: React.FC<LoginButtonProps> = ({
   ) => {
     if (web3Dependencies) {
       setWeb3Deps(web3Dependencies);
-      const loginResult = await loginWithAddress(web3Dependencies.address);
-      props.onLoginComplete(loginResult.address, loginResult.domain);
+      const {address, domain} = await loginWithAddress(
+        web3Dependencies.address,
+      );
+      onLoginComplete(address, domain);
       setAccessWalletOpen(false);
     }
   };

--- a/packages/ui-components/src/components/TokenGallery/NFTGalleryCarousel.tsx
+++ b/packages/ui-components/src/components/TokenGallery/NFTGalleryCarousel.tsx
@@ -81,20 +81,20 @@ const NFTGalleryCarousel = ({
    .swiper-button-next::after, .swiper-button-prev::after {
      font-size: var(--swiper-navigation-small);
    }
-    
+
  .swiper-button-prev, .swiper-button-next {
      box-sizing: border-box;
      width: 32px;
      height: 32px;
      background: rgba(255, 255, 255, 0.8);
-  
+
      border: 1px solid #DDDDDF;
      backdrop-filter: blur(2px);
- 
+
      border-radius: 50%;
   }
-  
- .swiper-wrapper { 
+
+ .swiper-wrapper {
   padding-bottom: 1rem;
  }
   `;
@@ -199,8 +199,8 @@ const NFTGalleryCarousel = ({
           className={classes.loadingContainer}
           spacing={2}
         >
-          {[...new Array(loadingCount)].map(v => (
-            <Grid item xs={12 / minNftCount} md={12 / maxNftCount}>
+          {[...new Array(loadingCount)].map((_, key) => (
+            <Grid key={key} item xs={12 / minNftCount} md={12 / maxNftCount}>
               <NftCard
                 compact={true}
                 nft={{

--- a/packages/ui-components/src/providers/BaseProvider.tsx
+++ b/packages/ui-components/src/providers/BaseProvider.tsx
@@ -1,4 +1,5 @@
 import CssBaseline from '@mui/material/CssBaseline';
+import type {Theme} from '@mui/material/styles';
 import {ThemeProvider} from '@mui/material/styles';
 import {SnackbarProvider} from 'notistack';
 import React from 'react';
@@ -24,20 +25,21 @@ const queryClient = new QueryClient({
 });
 
 // setup emotion cache for MUI
-const {EmotionCacheProvider, withEmotionCache} =
+export const {EmotionCacheProvider, withEmotionCache} =
   createEmotionSsrAdvancedApproach({key: 'css'});
-export {withEmotionCache};
 
 type Props = {
   children: React.ReactNode;
+  theme?: Theme;
 };
 
-const BaseProvider: React.FC<Props> = ({children}) => {
+const BaseProvider: React.FC<Props> = ({children, theme = lightTheme}) => {
   return (
     <TranslationProvider>
       <EmotionCacheProvider>
         <QueryClientProvider client={queryClient}>
-          <ThemeProvider theme={lightTheme}>
+          <ThemeProvider theme={theme}>
+            {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
             <CssBaseline enableColorScheme />
             <SnackbarProvider
               anchorOrigin={{

--- a/packages/ui-components/src/providers/DomainConfigProvider.tsx
+++ b/packages/ui-components/src/providers/DomainConfigProvider.tsx
@@ -1,7 +1,6 @@
 import React, {useState} from 'react';
 
 import {DomainProfileTabType} from '../components';
-import BaseProvider from './BaseProvider';
 
 type Props = {
   children: React.ReactNode;
@@ -31,11 +30,9 @@ const DomainConfigProvider: React.FC<Props> = ({children}) => {
   };
 
   return (
-    <BaseProvider>
-      <DomainConfigContext.Provider value={value}>
-        {children}
-      </DomainConfigContext.Provider>
-    </BaseProvider>
+    <DomainConfigContext.Provider value={value}>
+      {children}
+    </DomainConfigContext.Provider>
   );
 };
 

--- a/packages/ui-components/src/providers/TokenGalleryProvider.tsx
+++ b/packages/ui-components/src/providers/TokenGalleryProvider.tsx
@@ -1,7 +1,6 @@
 import React, {useState} from 'react';
 
 import type {Nft} from '../lib';
-import BaseProvider from './BaseProvider';
 
 type Props = {
   children: React.ReactNode;
@@ -33,11 +32,9 @@ const TokenGalleryProvider: React.FC<Props> = ({children}) => {
   };
 
   return (
-    <BaseProvider>
-      <TokenGalleryContext.Provider value={value}>
-        {children}
-      </TokenGalleryContext.Provider>
-    </BaseProvider>
+    <TokenGalleryContext.Provider value={value}>
+      {children}
+    </TokenGalleryContext.Provider>
   );
 };
 

--- a/packages/ui-components/src/providers/UnstoppableMessagingProvider.tsx
+++ b/packages/ui-components/src/providers/UnstoppableMessagingProvider.tsx
@@ -1,7 +1,5 @@
 import React, {useState} from 'react';
 
-import BaseProvider from './BaseProvider';
-
 type Props = {
   children: React.ReactNode;
 };
@@ -43,11 +41,9 @@ const UnstoppableMessagingProvider: React.FC<Props> = ({children}) => {
   };
 
   return (
-    <BaseProvider>
-      <UnstoppableMessagingContext.Provider value={value}>
-        {children}
-      </UnstoppableMessagingContext.Provider>
-    </BaseProvider>
+    <UnstoppableMessagingContext.Provider value={value}>
+      {children}
+    </UnstoppableMessagingContext.Provider>
   );
 };
 

--- a/packages/ui-components/src/tests/test-utils.tsx
+++ b/packages/ui-components/src/tests/test-utils.tsx
@@ -15,6 +15,7 @@ import * as actions from '../actions';
 import {TranslationProvider} from '../lib';
 import {
   DomainConfigProvider,
+  EmotionCacheProvider,
   TokenGalleryProvider,
   UnstoppableMessagingProvider,
   Web3ContextProvider,
@@ -36,20 +37,21 @@ const createWrapper =
   ({theme}: {theme?: Theme} = {}): React.FC =>
   ({children}) => (
     <QueryClientProvider client={createTestQueryClient()}>
-      {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-      <ThemeProvider theme={(theme || defaultTheme) as any}>
-        <SnackbarProvider>
-          <Web3ContextProvider>
-            <TokenGalleryProvider>
-              <UnstoppableMessagingProvider>
-                <DomainConfigProvider>
-                  <TranslationProvider>{children}</TranslationProvider>
-                </DomainConfigProvider>
-              </UnstoppableMessagingProvider>
-            </TokenGalleryProvider>
-          </Web3ContextProvider>
-        </SnackbarProvider>
-      </ThemeProvider>
+      <EmotionCacheProvider>
+        <ThemeProvider theme={theme || defaultTheme}>
+          <SnackbarProvider>
+            <Web3ContextProvider>
+              <TokenGalleryProvider>
+                <UnstoppableMessagingProvider>
+                  <DomainConfigProvider>
+                    <TranslationProvider>{children}</TranslationProvider>
+                  </DomainConfigProvider>
+                </UnstoppableMessagingProvider>
+              </TokenGalleryProvider>
+            </Web3ContextProvider>
+          </SnackbarProvider>
+        </ThemeProvider>
+      </EmotionCacheProvider>
     </QueryClientProvider>
   );
 

--- a/server/pages/[domain]/index.page.tsx
+++ b/server/pages/[domain]/index.page.tsx
@@ -707,6 +707,7 @@ const DomainProfile = ({
                           <div className={classes.followersPreview}>
                             {followers.slice(0, 3).map(follower => (
                               <DomainPreview
+                                key={follower}
                                 domain={follower}
                                 size={30}
                                 chatUser={chatUser}
@@ -747,7 +748,7 @@ const DomainProfile = ({
                           })
                           .map(account => {
                             return (
-                              <Box mr={1}>
+                              <Box mr={1} key={account}>
                                 <SocialAccountCard
                                   socialInfo={socialsInfo[account]}
                                   handleClickToCopy={handleClickToCopy}

--- a/server/pages/_app.page.tsx
+++ b/server/pages/_app.page.tsx
@@ -1,5 +1,3 @@
-import CssBaseline from '@mui/material/CssBaseline';
-import {ThemeProvider} from '@mui/material/styles';
 import Layout from 'components/app/Layout';
 import type {NextPage} from 'next';
 import {NextSeo} from 'next-seo';
@@ -10,6 +8,7 @@ import 'react-medium-image-zoom/dist/styles.css';
 import 'swiper/css/bundle';
 
 import {
+  BaseProvider,
   DomainConfigProvider,
   TokenGalleryProvider,
   UnstoppableMessagingProvider,
@@ -42,9 +41,7 @@ const WrappedApp = (props: WrappedAppProps) => {
         />
       </Head>
       <NextSeo title="Unstoppable Domains" />
-      <ThemeProvider theme={pageTheme}>
-        {/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
-        <CssBaseline enableColorScheme />
+      <BaseProvider theme={pageTheme}>
         <UnstoppableMessagingProvider>
           <TokenGalleryProvider>
             <DomainConfigProvider>
@@ -54,7 +51,7 @@ const WrappedApp = (props: WrappedAppProps) => {
             </DomainConfigProvider>
           </TokenGalleryProvider>
         </UnstoppableMessagingProvider>
-      </ThemeProvider>
+      </BaseProvider>
     </>
   );
 };

--- a/server/tests/test-utils.tsx
+++ b/server/tests/test-utils.tsx
@@ -28,22 +28,23 @@ const createWrapper =
   ({theme}: {theme?: Theme} = {}): React.FC =>
   ({children}) => (
     <QueryClientProvider client={createTestQueryClient()}>
-      {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
-      <ThemeProvider theme={(theme || defaultTheme) as any}>
-        <SnackbarProvider>
-          <uiComponents.Web3ContextProvider>
-            <uiComponents.TokenGalleryProvider>
-              <uiComponents.UnstoppableMessagingProvider>
-                <uiComponents.DomainConfigProvider>
-                  <uiComponents.TranslationProvider>
-                    {children}
-                  </uiComponents.TranslationProvider>
-                </uiComponents.DomainConfigProvider>
-              </uiComponents.UnstoppableMessagingProvider>
-            </uiComponents.TokenGalleryProvider>
-          </uiComponents.Web3ContextProvider>
-        </SnackbarProvider>
-      </ThemeProvider>
+      <uiComponents.EmotionCacheProvider>
+        <ThemeProvider theme={theme || defaultTheme}>
+          <SnackbarProvider>
+            <uiComponents.Web3ContextProvider>
+              <uiComponents.TokenGalleryProvider>
+                <uiComponents.UnstoppableMessagingProvider>
+                  <uiComponents.DomainConfigProvider>
+                    <uiComponents.TranslationProvider>
+                      {children}
+                    </uiComponents.TranslationProvider>
+                  </uiComponents.DomainConfigProvider>
+                </uiComponents.UnstoppableMessagingProvider>
+              </uiComponents.TokenGalleryProvider>
+            </uiComponents.Web3ContextProvider>
+          </SnackbarProvider>
+        </ThemeProvider>
+      </uiComponents.EmotionCacheProvider>
     </QueryClientProvider>
   );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4815,7 +4815,6 @@ __metadata:
     next-secure-headers: ^2.2.0
     next-seo: ^6.1.0
     next-transpile-modules: ^10.0.0
-    notistack: ^2.0.5
     numeral: ^2.0.6
     prettier: ^3.0.3
     prettier-plugin-organize-imports: ^3.2.3
@@ -4847,6 +4846,7 @@ __metadata:
     web3.storage: ^4.5.5
   peerDependencies:
     "@unstoppabledomains/ui-kit": ^0.3.15
+    notistack: ^2.0.5
     react-query: ^3.39.3
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
Currently, <BaseProvider/> is used in every Provider, as well as in the main App Wrapper. This creates unnecessary nesting, which can potentially cause issues.
In this PR, we:
- Reorganize context providers nesting
- Fix the react "key" issue in the console
- Stop passing `onLoginComplete` to Button as a prop
- Move `notistack` to `peerDependencies`