### PR TITLE
Migrate XMTP file uploads to W3-up service

### DIFF
--- a/client.jest.config.ts
+++ b/client.jest.config.ts
@@ -32,6 +32,8 @@ const config: InitialOptionsTsJest = {
   moduleNameMapper: {
     ['@xmtp/(.*)']: '<rootDir>/tests/mocks/empty.js',
     ['@pushprotocol/(.*)']: '<rootDir>/tests/mocks/empty.js',
+    ['@ipld/(.*)']: '<rootDir>/tests/mocks/empty.js',
+    ['@ucanto/(.*)']: '<rootDir>/tests/mocks/empty.js',
     'web3.storage': '<rootDir>/tests/mocks/empty.js',
     ['wagmi']: '<rootDir>/tests/mocks/empty.js',
     'react-medium-image-zoom': '<rootDir>/tests/mocks/empty.js',

--- a/packages/ui-components/CHANGELOG.md
+++ b/packages/ui-components/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.0.36
+
+- Update Web3 attachment uploads to w3-up service
+
 ## 0.0.35
 
 - Group chat support

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "@braintree/sanitize-url": "^6.0.4",
     "@emotion/server": "^11.4.0",
+    "@ipld/car": "^5.2.5",
     "@mui/icons-material": "5.10.3",
     "@mui/lab": "5.0.0-alpha.98",
     "@mui/material": "5.10.4",
@@ -52,6 +53,7 @@
     "@unstoppabledomains/config": "workspace:^",
     "@unstoppabledomains/resolution": "^8.5.0",
     "@web3-react/core": "^8.2.2",
+    "@web3-storage/w3up-client": "^12.0.0",
     "@xmtp/content-type-remote-attachment": "^1.1.4",
     "@xmtp/proto": "^3.35.0",
     "@xmtp/xmtp-js": "11.3.0",
@@ -98,8 +100,7 @@
     "typescript": "5.0.4",
     "uns": "https://github.com/unstoppabledomains/uns#v0.8.35",
     "usehooks-ts": "^2.9.1",
-    "wagmi": "^1.4.12",
-    "web3.storage": "^4.5.5"
+    "wagmi": "^1.4.12"
   },
   "devDependencies": {
     "@testing-library/react": "^12.1.2",

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unstoppabledomains/ui-components",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "private": true,
   "description": "An open and reusable suite of Unstoppable Domains management components",
   "keywords": [
@@ -100,7 +100,8 @@
     "typescript": "5.0.4",
     "uns": "https://github.com/unstoppabledomains/uns#v0.8.35",
     "usehooks-ts": "^2.9.1",
-    "wagmi": "^1.4.12"
+    "wagmi": "^1.4.12",
+    "web3.storage": "^4.5.5"
   },
   "devDependencies": {
     "@testing-library/react": "^12.1.2",

--- a/packages/ui-components/src/components/Chat/protocol/types.ts
+++ b/packages/ui-components/src/components/Chat/protocol/types.ts
@@ -1,0 +1,4 @@
+export type W3UpKey = {
+  key: string;
+  proof: string;
+};

--- a/packages/ui-components/src/components/Chat/protocol/upload.ts
+++ b/packages/ui-components/src/components/Chat/protocol/upload.ts
@@ -1,3 +1,5 @@
+import {CarReader} from '@ipld/car';
+import * as Delegation from '@ucanto/core/delegation';
 import type {Filelike} from 'web3.storage';
 
 export class Upload implements Filelike {
@@ -19,4 +21,15 @@ export class Upload implements Filelike {
       },
     });
   }
+}
+
+export async function parseW3UpProof(data: string) {
+  const blocks = [];
+  const reader = await CarReader.fromBytes(Buffer.from(data, 'base64'));
+  for await (const block of reader.blocks()) {
+    blocks.push(block);
+  }
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  return Delegation.importDAG(blocks);
 }

--- a/packages/ui-components/src/lib/sleep.ts
+++ b/packages/ui-components/src/lib/sleep.ts
@@ -1,0 +1,2 @@
+export const sleep = (ms: number) =>
+  new Promise(resolve => setTimeout(resolve, ms));

--- a/server/package.json
+++ b/server/package.json
@@ -82,8 +82,7 @@
     "truncate-eth-address": "^1.0.2",
     "tss-react": "^4.0.0",
     "typescript": "5.0.4",
-    "wagmi": "^1.4.12",
-    "web3.storage": "^4.5.5"
+    "wagmi": "^1.4.12"
   },
   "devDependencies": {
     "@swc/jest": "^0.2.22",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1435,6 +1435,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ipld/car@npm:^5.1.0, @ipld/car@npm:^5.1.1, @ipld/car@npm:^5.2.2, @ipld/car@npm:^5.2.5":
+  version: 5.2.6
+  resolution: "@ipld/car@npm:5.2.6"
+  dependencies:
+    "@ipld/dag-cbor": ^9.0.7
+    cborg: ^4.0.5
+    multiformats: ^13.0.0
+    varint: ^6.0.0
+  checksum: ce0ecd1949a6e45693a463c6b94574f3a95636afeb47cd338f21a508424d7107b060e426d54469e3d6eafe7ba638fbc4f4ad7164adba78224a381948a240d8f0
+  languageName: node
+  linkType: hard
+
 "@ipld/dag-cbor@npm:^6.0.3":
   version: 6.0.15
   resolution: "@ipld/dag-cbor@npm:6.0.15"
@@ -1455,12 +1467,68 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ipld/dag-cbor@npm:^9.0.0, @ipld/dag-cbor@npm:^9.0.5, @ipld/dag-cbor@npm:^9.0.6, @ipld/dag-cbor@npm:^9.0.7":
+  version: 9.0.8
+  resolution: "@ipld/dag-cbor@npm:9.0.8"
+  dependencies:
+    cborg: ^4.0.0
+    multiformats: ^13.0.0
+  checksum: 56a5352421a6977e1ad5a7871f2435ada808dbc2011fed52558e11c753e74dc2f1c874a91d46e3d271add7952a4b088a353d7788d76708153091496874c86bbd
+  languageName: node
+  linkType: hard
+
+"@ipld/dag-json@npm:^10.0.0":
+  version: 10.1.7
+  resolution: "@ipld/dag-json@npm:10.1.7"
+  dependencies:
+    cborg: ^4.0.0
+    multiformats: ^13.0.0
+  checksum: 2ac94d6471dd0e71acc65eb61e6617880b6f291d4c11cb70f717534734a88fdbae014b0aaf011bcad5599c002f749d01ec638820a2d1d8c464c3e4a59f6a4e8a
+  languageName: node
+  linkType: hard
+
 "@ipld/dag-pb@npm:^2.0.2":
   version: 2.1.18
   resolution: "@ipld/dag-pb@npm:2.1.18"
   dependencies:
     multiformats: ^9.5.4
   checksum: 46b9a7dabf6e87698fc268f88d94b710ba3988e26ab7918bcdf10c4356e15eb32393b6ab56eaf0d8936b369cb77456e491495f1025f78b099f1bd26cc5ccda06
+  languageName: node
+  linkType: hard
+
+"@ipld/dag-pb@npm:^4.0.0":
+  version: 4.0.8
+  resolution: "@ipld/dag-pb@npm:4.0.8"
+  dependencies:
+    multiformats: ^13.0.0
+  checksum: b322ffb412ca60f872ee9222dc802e4a68632e44e4ebbe1105465c62d3dac7265929cb0ddabf34105fc783c18225be7b6050be4ce18590620dec44c6ef088ff9
+  languageName: node
+  linkType: hard
+
+"@ipld/dag-ucan@npm:^3.4.0":
+  version: 3.4.0
+  resolution: "@ipld/dag-ucan@npm:3.4.0"
+  dependencies:
+    "@ipld/dag-cbor": ^9.0.0
+    "@ipld/dag-json": ^10.0.0
+    multiformats: ^11.0.0
+  checksum: 4b712b663c8dc90384125a4ac734901dac077693b8fe4a123283b39dec83f374f5d9d7cefd87c15cd3a87ba915572dc499911e620ca11b55333a844c906da3fb
+  languageName: node
+  linkType: hard
+
+"@ipld/unixfs@npm:^2.1.1":
+  version: 2.1.2
+  resolution: "@ipld/unixfs@npm:2.1.2"
+  dependencies:
+    "@ipld/dag-pb": ^4.0.0
+    "@multiformats/murmur3": ^2.1.3
+    "@perma/map": ^1.0.2
+    "@web-std/stream": 1.0.1
+    actor: ^2.3.1
+    multiformats: ^11.0.1
+    protobufjs: ^7.1.2
+    rabin-rs: ^2.1.0
+  checksum: 0bf9b30c3b47db4d43bb916943bc23f0280157d41865bddb9d64b497c708ca487ee9d15c369afa9a0047f86215c84d254dd1770e79b730ca04478a347cc00e95
   languageName: node
   linkType: hard
 
@@ -2437,6 +2505,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@multiformats/murmur3@npm:^2.1.0, @multiformats/murmur3@npm:^2.1.3":
+  version: 2.1.8
+  resolution: "@multiformats/murmur3@npm:2.1.8"
+  dependencies:
+    multiformats: ^13.0.0
+    murmurhash3js-revisited: ^3.0.0
+  checksum: 82841c87d4915c6a9540414c85931f1e17a848c9ff8ed51317e8bacddc9d9bfc2a7766699ccefcb9f0c8d7918584843f94d56b027619ee8c30dd09af26bfed8c
+  languageName: node
+  linkType: hard
+
 "@next/env@npm:12.3.4":
   version: 12.3.4
   resolution: "@next/env@npm:12.3.4"
@@ -2562,7 +2640,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/ed25519@npm:^1.5.1":
+"@noble/ed25519@npm:^1.5.1, @noble/ed25519@npm:^1.7.3":
   version: 1.7.3
   resolution: "@noble/ed25519@npm:1.7.3"
   checksum: 45169927d51de513e47bbeebff3a603433c4ac7579e1b8c5034c380a0afedbe85e6959be3d69584a7a5ed6828d638f8f28879003b9bb2fb5f22d8aa2d88fd5fe
@@ -2583,7 +2661,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@noble/hashes@npm:^1.1.5, @noble/hashes@npm:^1.2.0":
+"@noble/hashes@npm:^1.1.5, @noble/hashes@npm:^1.2.0, @noble/hashes@npm:^1.3.2":
   version: 1.3.3
   resolution: "@noble/hashes@npm:1.3.3"
   checksum: 8a6496d1c0c64797339bc694ad06cdfaa0f9e56cd0c3f68ae3666cfb153a791a55deb0af9c653c7ed2db64d537aa3e3054629740d2f2338bb1dcb7ab60cd205b
@@ -2813,6 +2891,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@perma/map@npm:^1.0.2":
+  version: 1.0.3
+  resolution: "@perma/map@npm:1.0.3"
+  dependencies:
+    "@multiformats/murmur3": ^2.1.0
+    murmurhash3js-revisited: ^3.0.0
+  checksum: 97ede1438c153cc878f55b9252a0cfc882c10df7772d8b973f1c5f7be967787327baead46e76d82853ea891ee29d45b34b025d52020ff670ba4d04e1d3571fe5
+  languageName: node
+  linkType: hard
+
 "@pkgjs/parseargs@npm:^0.11.0":
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
@@ -2994,6 +3082,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@scure/base@npm:~1.1.4":
+  version: 1.1.5
+  resolution: "@scure/base@npm:1.1.5"
+  checksum: 9e9ee6088cb3aa0fb91f5a48497d26682c7829df3019b1251d088d166d7a8c0f941c68aaa8e7b96bbad20c71eb210397cb1099062cde3e29d4bad6b975c18519
+  languageName: node
+  linkType: hard
+
 "@scure/bip32@npm:1.3.1":
   version: 1.3.1
   resolution: "@scure/bip32@npm:1.3.1"
@@ -3023,6 +3118,16 @@ __metadata:
     "@noble/hashes": ~1.3.0
     "@scure/base": ~1.1.0
   checksum: c5bd6f1328fdbeae2dcdd891825b1610225310e5e62a4942714db51066866e4f7bef242c7b06a1b9dcc8043a4a13412cf5c5df76d3b10aa9e36b82e9b6e3eeaa
+  languageName: node
+  linkType: hard
+
+"@scure/bip39@npm:^1.2.1":
+  version: 1.2.2
+  resolution: "@scure/bip39@npm:1.2.2"
+  dependencies:
+    "@noble/hashes": ~1.3.2
+    "@scure/base": ~1.1.4
+  checksum: cb99505e6d2deef8e55e81df8c563ce8dbfdf1595596dc912bceadcf366c91b05a98130e928ecb090df74efdb20150b64acc4be55bc42768cab4d39a2833d234
   languageName: node
   linkType: hard
 
@@ -4464,6 +4569,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/retry@npm:0.12.1":
+  version: 0.12.1
+  resolution: "@types/retry@npm:0.12.1"
+  checksum: 5f46b2556053655f78262bb33040dc58417c900457cc63ff37d6c35349814471453ef511af0cec76a540c601296cd2b22f64bab1ab649c0dacc0223765ba876c
+  languageName: node
+  linkType: hard
+
 "@types/scheduler@npm:*":
   version: 0.16.4
   resolution: "@types/scheduler@npm:0.16.4"
@@ -4742,6 +4854,77 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ucanto/client@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "@ucanto/client@npm:9.0.0"
+  dependencies:
+    "@ucanto/core": ^9.0.0
+    "@ucanto/interface": ^9.0.0
+  checksum: af001a50a77cdf85ed2d3d667fc0bc2f54a0aa13dcfa4dfff182720febc4982996391cd001ad154abb5d6ba17407a3390972eeb2ffe1a9ccb2fd0d4450287178
+  languageName: node
+  linkType: hard
+
+"@ucanto/core@npm:^9.0.0, @ucanto/core@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "@ucanto/core@npm:9.0.1"
+  dependencies:
+    "@ipld/car": ^5.1.0
+    "@ipld/dag-cbor": ^9.0.0
+    "@ipld/dag-ucan": ^3.4.0
+    "@ucanto/interface": ^9.0.0
+    multiformats: ^11.0.2
+  checksum: 4bf0b9f7b8558f59c9a97b3ed81f25b95fe963a034b41cc7d1defe537d23d1ef4fc1303581349c8beab0f98a1cc9b3715f0a03dbef06bfd04f7a41d8af86429a
+  languageName: node
+  linkType: hard
+
+"@ucanto/interface@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "@ucanto/interface@npm:9.0.0"
+  dependencies:
+    "@ipld/dag-ucan": ^3.4.0
+    multiformats: ^11.0.2
+  checksum: 113e50e3f118857c2deffcedb01e79e92f9c5b51c93fdb95b119dab1e12c2b92d57d4f6515da0c6168594b4decda28a475e24748b0b9177f2f75d6d95debf25d
+  languageName: node
+  linkType: hard
+
+"@ucanto/principal@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "@ucanto/principal@npm:9.0.0"
+  dependencies:
+    "@ipld/dag-ucan": ^3.4.0
+    "@noble/curves": ^1.2.0
+    "@noble/ed25519": ^1.7.3
+    "@noble/hashes": ^1.3.2
+    "@ucanto/interface": ^9.0.0
+    multiformats: ^11.0.2
+    one-webcrypto: ^1.0.3
+  checksum: 6e2ceee7a8ea2a2b103e6a9d855e22819a1101465bbb5eae1f5df382ed53674399fa6bda9f06fbc8b929db1ebd71134fd0d2227fee727b56a8f039986881ffec
+  languageName: node
+  linkType: hard
+
+"@ucanto/transport@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "@ucanto/transport@npm:9.0.0"
+  dependencies:
+    "@ucanto/core": ^9.0.0
+    "@ucanto/interface": ^9.0.0
+  checksum: 3da0721f892dcc0fea03c47b1ba9b7e400735f813cf801ed88f14809873e1f5df072d62d5588a3f2699b324ac69fb6f6d76a8a0c8597e89727220f4804eee764
+  languageName: node
+  linkType: hard
+
+"@ucanto/validator@npm:^9.0.1":
+  version: 9.0.1
+  resolution: "@ucanto/validator@npm:9.0.1"
+  dependencies:
+    "@ipld/car": ^5.1.0
+    "@ipld/dag-cbor": ^9.0.0
+    "@ucanto/core": ^9.0.1
+    "@ucanto/interface": ^9.0.0
+    multiformats: ^11.0.2
+  checksum: 100a706025b8e6984ffa5419652bfe0e6565b5e56a45c54cb768ccfb463edfeb0c897f4d8bb7752dd6fdf3154b7673c48ef4406bd7a1e3306f7febb784a8fee5
+  languageName: node
+  linkType: hard
+
 "@unstoppabledomains/config@workspace:^, @unstoppabledomains/config@workspace:packages/config":
   version: 0.0.0-use.local
   resolution: "@unstoppabledomains/config@workspace:packages/config"
@@ -4772,6 +4955,7 @@ __metadata:
   dependencies:
     "@braintree/sanitize-url": ^6.0.4
     "@emotion/server": ^11.4.0
+    "@ipld/car": ^5.2.5
     "@mui/icons-material": 5.10.3
     "@mui/lab": 5.0.0-alpha.98
     "@mui/material": 5.10.4
@@ -4801,6 +4985,7 @@ __metadata:
     "@unstoppabledomains/config": "workspace:^"
     "@unstoppabledomains/resolution": ^8.5.0
     "@web3-react/core": ^8.2.2
+    "@web3-storage/w3up-client": ^12.0.0
     "@xmtp/content-type-remote-attachment": ^1.1.4
     "@xmtp/proto": ^3.35.0
     "@xmtp/xmtp-js": 11.3.0
@@ -4853,7 +5038,6 @@ __metadata:
     uns: "https://github.com/unstoppabledomains/uns#v0.8.35"
     usehooks-ts: ^2.9.1
     wagmi: ^1.4.12
-    web3.storage: ^4.5.5
   peerDependencies:
     "@unstoppabledomains/ui-kit": ^0.3.15
     notistack: ^2.0.5
@@ -5472,6 +5656,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@web-std/stream@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@web-std/stream@npm:1.0.1"
+  dependencies:
+    web-streams-polyfill: ^3.1.1
+  checksum: 046df90d143c3308ee8f8b542c0bae6c84a8e5aeaf14c1ca3ff6625ddae4d59581e0f61dc840fbc29a803ca03dc6564c0004f24f1f3e2f33511799b0fbb21b28
+  languageName: node
+  linkType: hard
+
 "@web-std/stream@npm:^1.0.1":
   version: 1.0.3
   resolution: "@web-std/stream@npm:1.0.3"
@@ -5518,6 +5711,92 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@web3-storage/access@npm:^18.1.0":
+  version: 18.1.0
+  resolution: "@web3-storage/access@npm:18.1.0"
+  dependencies:
+    "@ipld/car": ^5.1.1
+    "@ipld/dag-ucan": ^3.4.0
+    "@scure/bip39": ^1.2.1
+    "@ucanto/client": ^9.0.0
+    "@ucanto/core": ^9.0.1
+    "@ucanto/interface": ^9.0.0
+    "@ucanto/principal": ^9.0.0
+    "@ucanto/transport": ^9.0.0
+    "@ucanto/validator": ^9.0.1
+    "@web3-storage/capabilities": ^13.0.0
+    "@web3-storage/did-mailto": ^2.1.0
+    bigint-mod-arith: ^3.1.2
+    conf: 11.0.2
+    multiformats: ^12.1.2
+    one-webcrypto: "git+https://github.com/web3-storage/one-webcrypto.git"
+    p-defer: ^4.0.0
+    type-fest: ^3.3.0
+    uint8arrays: ^4.0.6
+  checksum: d524e266dca41fa69ea02401c6e3bcb5d39010a5e7a284ba960f5616e0c4d40e4b3ee80d65e81458ed35ff95049e2c304afc40a28ae32aa8d67f1f983a161642
+  languageName: node
+  linkType: hard
+
+"@web3-storage/capabilities@npm:^12.1.0":
+  version: 12.1.0
+  resolution: "@web3-storage/capabilities@npm:12.1.0"
+  dependencies:
+    "@ucanto/core": ^9.0.1
+    "@ucanto/interface": ^9.0.0
+    "@ucanto/principal": ^9.0.0
+    "@ucanto/transport": ^9.0.0
+    "@ucanto/validator": ^9.0.1
+    "@web3-storage/data-segment": ^3.2.0
+  checksum: ee5578665e71a4d037c85603021c800d3eca74aa6df5a2d257e8a6d254f21d503fc59f86b07801d51404d54325852e27f92facba3273dbdca764877a1762e66c
+  languageName: node
+  linkType: hard
+
+"@web3-storage/capabilities@npm:^13.0.0":
+  version: 13.0.0
+  resolution: "@web3-storage/capabilities@npm:13.0.0"
+  dependencies:
+    "@ucanto/core": ^9.0.1
+    "@ucanto/interface": ^9.0.0
+    "@ucanto/principal": ^9.0.0
+    "@ucanto/transport": ^9.0.0
+    "@ucanto/validator": ^9.0.1
+    "@web3-storage/data-segment": ^3.2.0
+  checksum: 6754c304040588f687e0972b3cdd78a384e31cc7375410b6d03fa68f02ae7e23582c43f6341bec523b92d7f60e4ea802fce71fe27551ba05ba058a6427f26bf7
+  languageName: node
+  linkType: hard
+
+"@web3-storage/data-segment@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "@web3-storage/data-segment@npm:3.2.0"
+  dependencies:
+    "@ipld/dag-cbor": ^9.0.5
+    multiformats: ^11.0.2
+    sync-multihash-sha2: ^1.0.0
+  checksum: f37df468dc2da9a8215982c11dbc36800f35ebed3842a93247728651ccfaca2f7e1b1cb63b9d7cf1e9891189678482dae84fc030a17fa3512434a33dfca0fe3c
+  languageName: node
+  linkType: hard
+
+"@web3-storage/did-mailto@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@web3-storage/did-mailto@npm:2.1.0"
+  checksum: c7fb6214978e8540d890edc0077c531bc62d1d247cc14afcd11615508f46269b7c2b1e56ff799caf9065a1a31bfef6f13e2123b0b539c536d1043824b993f0f4
+  languageName: node
+  linkType: hard
+
+"@web3-storage/filecoin-client@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "@web3-storage/filecoin-client@npm:3.2.0"
+  dependencies:
+    "@ipld/dag-ucan": ^3.4.0
+    "@ucanto/client": ^9.0.0
+    "@ucanto/core": ^9.0.1
+    "@ucanto/interface": ^9.0.0
+    "@ucanto/transport": ^9.0.0
+    "@web3-storage/capabilities": ^12.1.0
+  checksum: 7d6f4a34ad4a12404e6083f13b42e020d5287f6f250914d57e0f22a06f1462c268b76626c04b27a3749b52b681964a671409437c0405ab9deca8c68ce425164c
+  languageName: node
+  linkType: hard
+
 "@web3-storage/multipart-parser@npm:^1.0.0":
   version: 1.0.0
   resolution: "@web3-storage/multipart-parser@npm:1.0.0"
@@ -5529,6 +5808,47 @@ __metadata:
   version: 3.1.0
   resolution: "@web3-storage/parse-link-header@npm:3.1.0"
   checksum: e91ce3ad25162ca84ecb8d607f54afc166ab91700c507a9cc81dac4ac6231d51cd307efdf1752f227046ef2cf255ada5e8fb6269703080f95a49b07ec90834a5
+  languageName: node
+  linkType: hard
+
+"@web3-storage/upload-client@npm:^13.0.0":
+  version: 13.0.0
+  resolution: "@web3-storage/upload-client@npm:13.0.0"
+  dependencies:
+    "@ipld/car": ^5.2.2
+    "@ipld/dag-cbor": ^9.0.6
+    "@ipld/dag-ucan": ^3.4.0
+    "@ipld/unixfs": ^2.1.1
+    "@ucanto/client": ^9.0.0
+    "@ucanto/interface": ^9.0.0
+    "@ucanto/transport": ^9.0.0
+    "@web3-storage/capabilities": ^13.0.0
+    fr32-sha2-256-trunc254-padded-binary-tree-multihash: ^3.1.1
+    ipfs-utils: ^9.0.14
+    multiformats: ^12.1.2
+    p-retry: ^5.1.2
+    parallel-transform-web: ^1.0.1
+    varint: ^6.0.0
+  checksum: 25b1761484d83b568d04fc6881aa95cb0ec457b1e06a5b08256bb93c775103efb0d566675e006fa4e5df1e94cffe9f0a09add5334b75a1c776b6d3db28ce89ef
+  languageName: node
+  linkType: hard
+
+"@web3-storage/w3up-client@npm:^12.0.0":
+  version: 12.0.0
+  resolution: "@web3-storage/w3up-client@npm:12.0.0"
+  dependencies:
+    "@ipld/dag-ucan": ^3.4.0
+    "@ucanto/client": ^9.0.0
+    "@ucanto/core": ^9.0.1
+    "@ucanto/interface": ^9.0.0
+    "@ucanto/principal": ^9.0.0
+    "@ucanto/transport": ^9.0.0
+    "@web3-storage/access": ^18.1.0
+    "@web3-storage/capabilities": ^13.0.0
+    "@web3-storage/did-mailto": ^2.1.0
+    "@web3-storage/filecoin-client": ^3.2.0
+    "@web3-storage/upload-client": ^13.0.0
+  checksum: 107d97e1f98f569576221a7154814601aba82ad68570bfc8a28de1288f5f93241701ef1f07de23363b8fbe4091a0df5199abc676bb0e5653077d096b05c41968
   languageName: node
   linkType: hard
 
@@ -5774,6 +6094,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"actor@npm:^2.3.1":
+  version: 2.3.1
+  resolution: "actor@npm:2.3.1"
+  checksum: dbca7224d97f060297b097a6ee7f275d221dc198326a3a3b63919d604ffdb89a27ca5a284bc5f75cd3e4622db926b3abc303dd3238893b4be2072012331132b9
+  languageName: node
+  linkType: hard
+
 "aes-js@npm:3.0.0":
   version: 3.0.0
   resolution: "aes-js@npm:3.0.0"
@@ -5816,6 +6143,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ajv-formats@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "ajv-formats@npm:2.1.1"
+  dependencies:
+    ajv: ^8.0.0
+  peerDependencies:
+    ajv: ^8.0.0
+  peerDependenciesMeta:
+    ajv:
+      optional: true
+  checksum: 4a287d937f1ebaad4683249a4c40c0fa3beed30d9ddc0adba04859026a622da0d317851316ea64b3680dc60f5c3c708105ddd5d5db8fe595d9d0207fd19f90b7
+  languageName: node
+  linkType: hard
+
 "ajv@npm:^6.12.3, ajv@npm:^6.12.4":
   version: 6.12.6
   resolution: "ajv@npm:6.12.6"
@@ -5825,6 +6166,18 @@ __metadata:
     json-schema-traverse: ^0.4.1
     uri-js: ^4.2.2
   checksum: 874972efe5c4202ab0a68379481fbd3d1b5d0a7bd6d3cc21d40d3536ebff3352a2a1fabb632d4fd2cc7fe4cbdcd5ed6782084c9bbf7f32a1536d18f9da5007d4
+  languageName: node
+  linkType: hard
+
+"ajv@npm:^8.0.0, ajv@npm:^8.12.0":
+  version: 8.12.0
+  resolution: "ajv@npm:8.12.0"
+  dependencies:
+    fast-deep-equal: ^3.1.1
+    json-schema-traverse: ^1.0.0
+    require-from-string: ^2.0.2
+    uri-js: ^4.2.2
+  checksum: 4dc13714e316e67537c8b31bc063f99a1d9d9a497eb4bbd55191ac0dcd5e4985bbb71570352ad6f1e76684fb6d790928f96ba3b2d4fd6e10024be9612fe3f001
   languageName: node
   linkType: hard
 
@@ -6234,6 +6587,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"atomically@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "atomically@npm:2.0.2"
+  dependencies:
+    stubborn-fs: ^1.2.5
+    when-exit: ^2.0.0
+  checksum: a7f65bbff14278f38fb85b82924ca7d0cbac91c046d106099eb895bfcf8b89490370a55d3661099ec2c55a02fab57f47321f0f257ca2832081485261cc98f46e
+  languageName: node
+  linkType: hard
+
 "available-typed-arrays@npm:^1.0.5":
   version: 1.0.5
   resolution: "available-typed-arrays@npm:1.0.5"
@@ -6471,6 +6834,13 @@ __metadata:
     bindings: ^1.3.0
     node-gyp: latest
   checksum: d010c9f57758bcdaccb435d88b483ffcc95fe8bbc6e7fb3a44fb5221f29c894ffaf4a3c5a4a530e0e7d6608203c2cde9b79ee4f2386cd6d4462d1070bc8c9f4e
+  languageName: node
+  linkType: hard
+
+"bigint-mod-arith@npm:^3.1.2":
+  version: 3.3.1
+  resolution: "bigint-mod-arith@npm:3.3.1"
+  checksum: 23f2fc67611cf99ce9c3b6f386cb50a363a467204f088f8fbda76def4642aaf0c41aced1f46521b1a52d25b492c9558d4cef1b807e16fbf9535700a4e8909c32
   languageName: node
   linkType: hard
 
@@ -7156,6 +7526,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cborg@npm:^4.0.0, cborg@npm:^4.0.5":
+  version: 4.0.7
+  resolution: "cborg@npm:4.0.7"
+  bin:
+    cborg: lib/bin.js
+  checksum: cf2159338848adbf9cf4301cd4091722e220185920a2b1634750a2a71ce54a8ae6e1aed2220c3a3eeebe80870a255654527d9c72ec1cd0c8c60d5091711c61ec
+  languageName: node
+  linkType: hard
+
 "ccount@npm:^2.0.0":
   version: 2.0.1
   resolution: "ccount@npm:2.0.1"
@@ -7632,6 +8011,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"conf@npm:11.0.2":
+  version: 11.0.2
+  resolution: "conf@npm:11.0.2"
+  dependencies:
+    ajv: ^8.12.0
+    ajv-formats: ^2.1.1
+    atomically: ^2.0.0
+    debounce-fn: ^5.1.2
+    dot-prop: ^7.2.0
+    env-paths: ^3.0.0
+    json-schema-typed: ^8.0.1
+    semver: ^7.3.8
+  checksum: 4b4ff645bfd6e25f7595f909906f711dd3ebeb3e462d2ee8d27430991c0757d783968a8f36367d7db1401b022f9a7cebeaf43da816b80753dbad8cca12118215
+  languageName: node
+  linkType: hard
+
 "confusing-browser-globals@npm:^1.0.10":
   version: 1.0.11
   resolution: "confusing-browser-globals@npm:1.0.11"
@@ -8025,6 +8420,15 @@ __metadata:
   dependencies:
     "@babel/runtime": ^7.21.0
   checksum: f7be01523282e9bb06c0cd2693d34f245247a29098527d4420628966a2d9aad154bd0e90a6b1cf66d37adcb769cd108cf8a7bd49d76db0fb119af5cdd13644f4
+  languageName: node
+  linkType: hard
+
+"debounce-fn@npm:^5.1.2":
+  version: 5.1.2
+  resolution: "debounce-fn@npm:5.1.2"
+  dependencies:
+    mimic-fn: ^4.0.0
+  checksum: d0d1e84bae3b96c1ba108430700b1b6f775275029d731b0a050ae6af0984933bfeec6d35cc7058f3f929bde627017a0fc16feda5dc4eb940f03be60d8b3704db
   languageName: node
   linkType: hard
 
@@ -8517,6 +8921,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"dot-prop@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "dot-prop@npm:7.2.0"
+  dependencies:
+    type-fest: ^2.11.2
+  checksum: 08e4ff14f7305ffb5fda7e4c88f3cdbeb3cd97bd27efa4f47503869a2ee7f96938b4c21b0a2abf9c37d891a1bdb3994a09d219b0dcfd6130da4eaeb44c6f067e
+  languageName: node
+  linkType: hard
+
 "dotenv@npm:^16.3.1":
   version: 16.3.1
   resolution: "dotenv@npm:16.3.1"
@@ -8734,6 +9147,13 @@ __metadata:
   version: 2.2.1
   resolution: "env-paths@npm:2.2.1"
   checksum: 65b5df55a8bab92229ab2b40dad3b387fad24613263d103a97f91c9fe43ceb21965cd3392b1ccb5d77088021e525c4e0481adb309625d0cb94ade1d1fb8dc17e
+  languageName: node
+  linkType: hard
+
+"env-paths@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "env-paths@npm:3.0.0"
+  checksum: b2b0a0d0d9931a13d279c22ed94d78648a1cc5f408f05d47ff3e0c1616f0aa0c38fb33deec5e5be50497225d500607d57f9c8652c4d39c2f2b7608cd45768128
   languageName: node
   linkType: hard
 
@@ -10333,6 +10753,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fr32-sha2-256-trunc254-padded-binary-tree-multihash@npm:^3.1.1":
+  version: 3.1.1
+  resolution: "fr32-sha2-256-trunc254-padded-binary-tree-multihash@npm:3.1.1"
+  checksum: a685f90fb9ec4b4018796e6a280114d36bfb72b57b662e521328d6ca4dead4a48743d4d6c1c9c3afc8948ade13250f16d1d52baa56a6ba871f0287aca479807a
+  languageName: node
+  linkType: hard
+
 "fresh@npm:0.5.2":
   version: 0.5.2
   resolution: "fresh@npm:0.5.2"
@@ -11576,7 +12003,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ipfs-utils@npm:^9.0.2":
+"ipfs-utils@npm:^9.0.14, ipfs-utils@npm:^9.0.2":
   version: 9.0.14
   resolution: "ipfs-utils@npm:9.0.14"
   dependencies:
@@ -13175,6 +13602,20 @@ __metadata:
   version: 0.4.1
   resolution: "json-schema-traverse@npm:0.4.1"
   checksum: 7486074d3ba247769fda17d5181b345c9fb7d12e0da98b22d1d71a5db9698d8b4bd900a3ec1a4ffdd60846fc2556274a5c894d0c48795f14cb03aeae7b55260b
+  languageName: node
+  linkType: hard
+
+"json-schema-traverse@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "json-schema-traverse@npm:1.0.0"
+  checksum: 02f2f466cdb0362558b2f1fd5e15cce82ef55d60cd7f8fa828cf35ba74330f8d767fcae5c5c2adb7851fa811766c694b9405810879bc4e1ddd78a7c0e03658ad
+  languageName: node
+  linkType: hard
+
+"json-schema-typed@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "json-schema-typed@npm:8.0.1"
+  checksum: c7d47c05553dec15841d7940af146337667fcb775c4e29e10107792a0319909af92ee128a7cb8100464f3be26895d31827799268556e930d2d85bc443fb586ac
   languageName: node
   linkType: hard
 
@@ -15040,6 +15481,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"multiformats@npm:^11.0.0, multiformats@npm:^11.0.1, multiformats@npm:^11.0.2":
+  version: 11.0.2
+  resolution: "multiformats@npm:11.0.2"
+  checksum: e587bbe709f29e42ae3c22458c960070269027d962183afc49a83b8ba26c31525e81ce2ac71082a52ba0a75e9aed4d0d044cac68d32656fdcd5cd340fb367fac
+  languageName: node
+  linkType: hard
+
+"multiformats@npm:^12.0.1, multiformats@npm:^12.1.2":
+  version: 12.1.3
+  resolution: "multiformats@npm:12.1.3"
+  checksum: 1060488612f8e6729c600f47a8741b91aa6e7b807ce165eca3c8cf07ab7465d2d9b212415a9c18886938b9e35b30ea7b9ae19b5ab5122589c65063440643e6bb
+  languageName: node
+  linkType: hard
+
+"multiformats@npm:^13.0.0":
+  version: 13.0.1
+  resolution: "multiformats@npm:13.0.1"
+  checksum: 63e5d6ee2c2a1d1e8fbd4b8c76fa41cf3d8204ceed1d57bc44cb30ff3d06b880ad58c3de52ae6d4397a662a6f1e3285dae74ee5d445fd1597516e1baec96d22a
+  languageName: node
+  linkType: hard
+
 "multihashes@npm:^0.4.15, multihashes@npm:~0.4.15":
   version: 0.4.21
   resolution: "multihashes@npm:0.4.21"
@@ -15716,6 +16178,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"one-webcrypto@git+https://github.com/web3-storage/one-webcrypto.git":
+  version: 1.0.3
+  resolution: "one-webcrypto@https://github.com/web3-storage/one-webcrypto.git#commit=5148cd14d5489a8ac4cd38223870e02db15a2382"
+  checksum: 57dc46707845446730751f0619120fcadda709c6a669609083845fa6dc2649af0cb4c493e007c3aef3247072dc1b4922cfc1c5a0aef18721054d5a8a6c7f43e3
+  languageName: node
+  linkType: hard
+
+"one-webcrypto@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "one-webcrypto@npm:1.0.3"
+  checksum: b7df09a4ef30fc6708a45517a43c26ada7b2642ca319a8bf68d1b156c277d8d198897645a0d5ccf7e67c6b3e9a30578698889aea594bfdd9f1e23130f8889817
+  languageName: node
+  linkType: hard
+
 "onetime@npm:^5.1.0, onetime@npm:^5.1.2":
   version: 5.1.2
   resolution: "onetime@npm:5.1.2"
@@ -15799,6 +16275,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"p-defer@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "p-defer@npm:4.0.0"
+  checksum: 646c9e86e62d2299ee9e8722b9857c9a2918afb8626c4eaf072d956de0d5b33c1cb132e5754516c923fc691eb33aa216755e168f848b045c1279186c8e2d852f
+  languageName: node
+  linkType: hard
+
 "p-fifo@npm:^1.0.0":
   version: 1.0.0
   resolution: "p-fifo@npm:1.0.0"
@@ -15871,10 +16354,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"p-retry@npm:^5.1.2":
+  version: 5.1.2
+  resolution: "p-retry@npm:5.1.2"
+  dependencies:
+    "@types/retry": 0.12.1
+    retry: ^0.13.1
+  checksum: f063c08b1adc3cf7c01de01eb2dbda841970229f9f229c5167ebf4e2080d8a38b1f4e6eccefac74bca97cfaf4436d0a0eeb0b551175b26bc8b3116195f61bba8
+  languageName: node
+  linkType: hard
+
 "p-try@npm:^2.0.0":
   version: 2.2.0
   resolution: "p-try@npm:2.2.0"
   checksum: f8a8e9a7693659383f06aec604ad5ead237c7a261c18048a6e1b5b85a5f8a067e469aa24f5bc009b991ea3b058a87f5065ef4176793a200d4917349881216cae
+  languageName: node
+  linkType: hard
+
+"parallel-transform-web@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "parallel-transform-web@npm:1.0.1"
+  checksum: 681c5e419e4eeb5ab49d23d835a7feaa968579bd7f6003b2b0ef6343865d19f10e3018d83363e46ed3f487c73fc1e7781156f96c836400ac7036c52550525016
   languageName: node
   linkType: hard
 
@@ -16606,7 +17106,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"protobufjs@npm:^7.0.0":
+"protobufjs@npm:^7.0.0, protobufjs@npm:^7.1.2":
   version: 7.2.5
   resolution: "protobufjs@npm:7.2.5"
   dependencies:
@@ -16801,6 +17301,13 @@ __metadata:
   version: 5.1.1
   resolution: "quick-lru@npm:5.1.1"
   checksum: a516faa25574be7947969883e6068dbe4aa19e8ef8e8e0fd96cddd6d36485e9106d85c0041a27153286b0770b381328f4072aa40d3b18a19f5f7d2b78b94b5ed
+  languageName: node
+  linkType: hard
+
+"rabin-rs@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "rabin-rs@npm:2.1.0"
+  checksum: eaa21179abd3e65277cadc388f923ea897386a42baa89ad8396d03b46c9448c80b3f4482e6591d590127e61ab8f20492c3c825a8a23d4e4af1302a1d42620103
   languageName: node
   linkType: hard
 
@@ -17398,6 +17905,13 @@ __metadata:
   version: 2.1.1
   resolution: "require-directory@npm:2.1.1"
   checksum: fb47e70bf0001fdeabdc0429d431863e9475e7e43ea5f94ad86503d918423c1543361cc5166d713eaa7029dd7a3d34775af04764bebff99ef413111a5af18c80
+  languageName: node
+  linkType: hard
+
+"require-from-string@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "require-from-string@npm:2.0.2"
+  checksum: a03ef6895445f33a4015300c426699bc66b2b044ba7b670aa238610381b56d3f07c686251740d575e22f4c87531ba662d06937508f0f3c0f1ddc04db3130560b
   languageName: node
   linkType: hard
 
@@ -18767,6 +19281,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stubborn-fs@npm:^1.2.5":
+  version: 1.2.5
+  resolution: "stubborn-fs@npm:1.2.5"
+  checksum: 28d197afec1ec21ce7ffb06a42f01db19beecdf491694c53393ff5d92ec8a300df9c357e09a16d5cf55747ee2a70bc3c788b9e5577696061ffb9ae279655a600
+  languageName: node
+  linkType: hard
+
 "style-inject@npm:0.3.0":
   version: 0.3.0
   resolution: "style-inject@npm:0.3.0"
@@ -18939,6 +19460,15 @@ __metadata:
   version: 3.2.4
   resolution: "symbol-tree@npm:3.2.4"
   checksum: 6e8fc7e1486b8b54bea91199d9535bb72f10842e40c79e882fc94fb7b14b89866adf2fd79efa5ebb5b658bc07fb459ccce5ac0e99ef3d72f474e74aaf284029d
+  languageName: node
+  linkType: hard
+
+"sync-multihash-sha2@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "sync-multihash-sha2@npm:1.0.0"
+  dependencies:
+    "@noble/hashes": ^1.3.1
+  checksum: 4cff79eb105be4b91593ce736454979dad6b3fd44b94007180941a652272be35646710302a705742998ff4ffa928cdc12d023cbbc9ef1f656d3fcc20f07451ca
   languageName: node
   linkType: hard
 
@@ -19568,6 +20098,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"type-fest@npm:^2.11.2":
+  version: 2.19.0
+  resolution: "type-fest@npm:2.19.0"
+  checksum: a4ef07ece297c9fba78fc1bd6d85dff4472fe043ede98bd4710d2615d15776902b595abf62bd78339ed6278f021235fb28a96361f8be86ed754f778973a0d278
+  languageName: node
+  linkType: hard
+
+"type-fest@npm:^3.3.0":
+  version: 3.13.1
+  resolution: "type-fest@npm:3.13.1"
+  checksum: c06b0901d54391dc46de3802375f5579868949d71f93b425ce564e19a428a0d411ae8d8cb0e300d330071d86152c3ea86e744c3f2860a42a79585b6ec2fdae8e
+  languageName: node
+  linkType: hard
+
 "type-is@npm:~1.6.18":
   version: 1.6.18
   resolution: "type-is@npm:1.6.18"
@@ -19711,6 +20255,15 @@ __metadata:
   dependencies:
     multiformats: ^9.4.2
   checksum: b93b6c3f0a526b116799f3a3409bd4b5d5553eb3e73e485998ece7974742254fbc0d2f7988dd21ac86c4b974552f45d9ae9cf9cba9647e529f8eb1fdd2ed84d0
+  languageName: node
+  linkType: hard
+
+"uint8arrays@npm:^4.0.6":
+  version: 4.0.10
+  resolution: "uint8arrays@npm:4.0.10"
+  dependencies:
+    multiformats: ^12.0.1
+  checksum: 784677a00f67d18d3aaaf441422b4055576e1ab76dbf276e474b86c91ddb95945ac1cc95a97979ab1f3b3c9a0ebeea74dd803ec6056adbd1ee6ef2f231f00f97
   languageName: node
   linkType: hard
 
@@ -20896,6 +21449,13 @@ __metadata:
     tr46: ~0.0.3
     webidl-conversions: ^3.0.0
   checksum: b8daed4ad3356cc4899048a15b2c143a9aed0dfae1f611ebd55073310c7b910f522ad75d727346ad64203d7e6c79ef25eafd465f4d12775ca44b90fa82ed9e2c
+  languageName: node
+  linkType: hard
+
+"when-exit@npm:^2.0.0":
+  version: 2.1.2
+  resolution: "when-exit@npm:2.1.2"
+  checksum: 760c19ede5c584cec612b4790a8bbaae4d20d701fb06ffd48afddf02832a5da5a75acf303d770ed61fe565489e54ed632f3310c618f5400183394ffce19e27ce
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4288,9 +4288,9 @@ __metadata:
   linkType: hard
 
 "@types/minimist@npm:^1.2.0":
-  version: 1.2.3
-  resolution: "@types/minimist@npm:1.2.3"
-  checksum: 666ea4f8c39dcbdfbc3171fe6b3902157c845cc9cb8cee33c10deb706cda5e0cc80f98ace2d6d29f6774b0dc21180c96cd73c592a1cbefe04777247c7ba0e84b
+  version: 1.2.5
+  resolution: "@types/minimist@npm:1.2.5"
+  checksum: 477047b606005058ab0263c4f58097136268007f320003c348794f74adedc3166ffc47c80ec3e94687787f2ab7f4e72c468223946e79892cf0fd9e25e9970a90
   languageName: node
   linkType: hard
 
@@ -4348,9 +4348,9 @@ __metadata:
   linkType: hard
 
 "@types/normalize-package-data@npm:^2.4.0":
-  version: 2.4.2
-  resolution: "@types/normalize-package-data@npm:2.4.2"
-  checksum: 2132e4054711e6118de967ae3a34f8c564e58d71fbcab678ec2c34c14659f638a86c35a0fd45237ea35a4a03079cf0a485e3f97736ffba5ed647bfb5da086b03
+  version: 2.4.4
+  resolution: "@types/normalize-package-data@npm:2.4.4"
+  checksum: 65dff72b543997b7be8b0265eca7ace0e34b75c3e5fee31de11179d08fa7124a7a5587265d53d0409532ecb7f7fba662c2012807963e1f9b059653ec2c83ee05
   languageName: node
   linkType: hard
 
@@ -5038,6 +5038,7 @@ __metadata:
     uns: "https://github.com/unstoppabledomains/uns#v0.8.35"
     usehooks-ts: ^2.9.1
     wagmi: ^1.4.12
+    web3.storage: ^4.5.5
   peerDependencies:
     "@unstoppabledomains/ui-kit": ^0.3.15
     notistack: ^2.0.5
@@ -10838,6 +10839,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"function-bind@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "function-bind@npm:1.1.2"
+  checksum: 2b0ff4ce708d99715ad14a6d1f894e2a83242e4a52ccfcefaee5e40050562e5f6dafc1adbb4ce2d4ab47279a45dc736ab91ea5042d843c3c092820dfe032efb1
+  languageName: node
+  linkType: hard
+
 "function.prototype.name@npm:^1.1.5, function.prototype.name@npm:^1.1.6":
   version: 1.1.6
   resolution: "function.prototype.name@npm:1.1.6"
@@ -11405,6 +11413,15 @@ __metadata:
     inherits: ^2.0.3
     minimalistic-assert: ^1.0.1
   checksum: e350096e659c62422b85fa508e4b3669017311aa4c49b74f19f8e1bc7f3a54a584fdfd45326d4964d6011f2b2d882e38bea775a96046f2a61b7779a979629d8f
+  languageName: node
+  linkType: hard
+
+"hasown@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "hasown@npm:2.0.0"
+  dependencies:
+    function-bind: ^1.1.2
+  checksum: 6151c75ca12554565098641c98a40f4cc86b85b0fd5b6fe92360967e4605a4f9610f7757260b4e8098dd1c2ce7f4b095f2006fe72a570e3b6d2d28de0298c176
   languageName: node
   linkType: hard
 
@@ -12173,12 +12190,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-core-module@npm:^2.13.0, is-core-module@npm:^2.5.0":
+"is-core-module@npm:^2.13.0":
   version: 2.13.0
   resolution: "is-core-module@npm:2.13.0"
   dependencies:
     has: ^1.0.3
   checksum: 053ab101fb390bfeb2333360fd131387bed54e476b26860dc7f5a700bbf34a0ec4454f7c8c4d43e8a0030957e4b3db6e16d35e1890ea6fb654c833095e040355
+  languageName: node
+  linkType: hard
+
+"is-core-module@npm:^2.5.0":
+  version: 2.13.1
+  resolution: "is-core-module@npm:2.13.1"
+  dependencies:
+    hasown: ^2.0.0
+  checksum: 256559ee8a9488af90e4bad16f5583c6d59e92f0742e9e8bb4331e758521ee86b810b93bae44f390766ffbc518a0488b18d9dab7da9a5ff997d499efc9403f7c
   languageName: node
   linkType: hard
 
@@ -15569,7 +15595,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.0.2, nanoid@npm:^3.1.20, nanoid@npm:^3.1.23, nanoid@npm:^3.3.4, nanoid@npm:^3.3.6":
+"nanoid@npm:^3.0.2, nanoid@npm:^3.1.23":
+  version: 3.3.7
+  resolution: "nanoid@npm:3.3.7"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: d36c427e530713e4ac6567d488b489a36582ef89da1d6d4e3b87eded11eb10d7042a877958c6f104929809b2ab0bafa17652b076cdf84324aa75b30b722204f2
+  languageName: node
+  linkType: hard
+
+"nanoid@npm:^3.1.20, nanoid@npm:^3.3.4, nanoid@npm:^3.3.6":
   version: 3.3.6
   resolution: "nanoid@npm:3.3.6"
   bin:
@@ -18463,7 +18498,6 @@ __metadata:
     tss-react: ^4.0.0
     typescript: 5.0.4
     wagmi: ^1.4.12
-    web3.storage: ^4.5.5
   dependenciesMeta:
     "@next/swc-linux-x64-gnu":
       optional: true


### PR DESCRIPTION
The previously used storage service from https://web3.storage has been discontinued, and clients are no longer able to upload new files using this approach. There is a new Web3 file management service from the same provider, but requires code and key updates in order to work.

This PR is based on the XMTP sample app update: https://github.com/xmtp-labs/xmtp-inbox-web/pull/416

Notes:
- Attachments UX remains unchanged, the underlying upload mechanism is only updated
- Previously uploaded files are still available

## Screenshots
### Sample uploads using the new w3-up service
<img width="441" alt="image" src="https://github.com/unstoppabledomains/domain-profiles/assets/21039114/29f64d20-86c7-4862-a490-bb4c4951ddce">
