### PR TITLE
Add mouseover effect to group chat options

### DIFF
--- a/packages/ui-components/CHANGELOG.md
+++ b/packages/ui-components/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.0.37
+
+- Block list support for group chat
+
 ## 0.0.36
 
 - Update Web3 attachment uploads to w3-up service

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unstoppabledomains/ui-components",
-  "version": "0.0.36",
+  "version": "0.0.37",
   "private": true,
   "description": "An open and reusable suite of Unstoppable Domains management components",
   "keywords": [

--- a/packages/ui-components/src/components/Chat/modal/ChatModal.tsx
+++ b/packages/ui-components/src/components/Chat/modal/ChatModal.tsx
@@ -68,6 +68,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
     width: '450px',
     height: '600px',
     margin: theme.spacing(1),
+    boxShadow: theme.shadows[6],
     zIndex: 200,
     [theme.breakpoints.down('sm')]: {
       width: '100%',
@@ -775,7 +776,7 @@ export const ChatModal: React.FC<ChatModalProps> = ({
     <Card
       className={classes.chatModalContainer}
       sx={{display: open ? '' : 'none'}}
-      elevation={2}
+      variant="elevation"
     >
       {conversationSearch ? (
         <ConversationStart

--- a/packages/ui-components/src/components/Chat/modal/group/Community.tsx
+++ b/packages/ui-components/src/components/Chat/modal/group/Community.tsx
@@ -469,6 +469,7 @@ export const Community: React.FC<CommunityProps> = ({
         <DomainListModal
           id="groupMembers"
           title={t('push.memberCount', {count: groupInfo?.members.length || 0})}
+          subtitle={t('push.memberCountDescription', {name: badge.name})}
           open={isViewingMemberList}
           onClose={() => setIsViewingMemberList(false)}
           onClick={(domain: string) =>

--- a/packages/ui-components/src/components/Chat/modal/group/CommunityConversationBubble.tsx
+++ b/packages/ui-components/src/components/Chat/modal/group/CommunityConversationBubble.tsx
@@ -3,9 +3,11 @@ import BlockIcon from '@mui/icons-material/Block';
 import DownloadIcon from '@mui/icons-material/Download';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
+import MoreHorizIcon from '@mui/icons-material/MoreHoriz';
 import Avatar from '@mui/material/Avatar';
 import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
+import IconButton from '@mui/material/IconButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
@@ -50,6 +52,7 @@ export const CommunityConversationBubble: React.FC<
   const messageRef = useRef<HTMLElement>(null);
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [isBlocking, setIsBlocking] = useState(false);
+  const [isMouseOver, setIsMouseOver] = useState(false);
   const [isDecrypting, setIsDecrypting] = useState(true);
   const [isDecryptionError, setIsDecryptionError] = useState(false);
   const [isMediaLoading, setIsMediaLoading] = useState(false);
@@ -77,6 +80,14 @@ export const CommunityConversationBubble: React.FC<
     const blockFn = blocked ? onUnblockUser : onBlockUser;
     await blockFn();
     setIsBlocking(false);
+  };
+
+  const handleMouseOver = () => {
+    setIsMouseOver(true);
+  };
+
+  const handleMouseOut = () => {
+    setIsMouseOver(false);
   };
 
   const renderPeerAvatar = async (peerAddress: string) => {
@@ -262,6 +273,20 @@ export const CommunityConversationBubble: React.FC<
       </Box>
     ) : (
       <Box
+        onMouseOver={
+          encryptedMessage.fromCAIP10
+            .toLowerCase()
+            .includes(address.toLowerCase())
+            ? undefined
+            : handleMouseOver
+        }
+        onMouseOut={
+          encryptedMessage.fromCAIP10
+            .toLowerCase()
+            .includes(address.toLowerCase())
+            ? undefined
+            : handleMouseOut
+        }
         ref={messageRef}
         className={cx(
           encryptedMessage.fromCAIP10
@@ -318,12 +343,12 @@ export const CommunityConversationBubble: React.FC<
                 <MenuItem onClick={handleBlockUser}>
                   <ListItemIcon>
                     {isBlocking ? (
-                      <CircularProgress size={16} color="inherit" />
+                      <CircularProgress size={16} color="error" />
                     ) : (
-                      <BlockIcon fontSize="small" />
+                      <BlockIcon color="error" fontSize="small" />
                     )}
                   </ListItemIcon>
-                  <Typography variant="body2">
+                  <Typography variant="body2" className={classes.blockColor}>
                     {blocked ? t('manage.unblock') : t('push.blockAndReport')}
                   </Typography>
                 </MenuItem>
@@ -405,6 +430,16 @@ export const CommunityConversationBubble: React.FC<
             onClose={() => setClickedUrl(undefined)}
           />
         )}
+        <Box onMouseOver={handleMouseOver} className={classes.optionsContainer}>
+          <IconButton onClick={handleOpenMenu}>
+            <MoreHorizIcon
+              className={
+                isMouseOver ? classes.optionsIconOn : classes.optionsIconOff
+              }
+              fontSize="small"
+            />
+          </IconButton>
+        </Box>
       </Box>
     )
   ) : (

--- a/packages/ui-components/src/components/Chat/modal/styles.ts
+++ b/packages/ui-components/src/components/Chat/modal/styles.ts
@@ -29,7 +29,24 @@ export const useConversationBubbleStyles = makeStyles<{
     display: 'inline-block',
     wordBreak: 'break-word',
   },
+  optionsContainer: {
+    marginTop: theme.spacing(2),
+    marginRight: theme.spacing(-5),
+    position: 'absolute',
+    right: 0,
+    top: 0,
+  },
+  blockColor: {
+    color: theme.palette.error.main,
+  },
+  optionsIconOn: {
+    color: theme.palette.neutralShades[400],
+  },
+  optionsIconOff: {
+    color: theme.palette.white,
+  },
   leftRow: {
+    position: 'relative',
     display: 'inline-block',
     textAlign: 'left',
   },

--- a/packages/ui-components/src/components/Domain/DomainListModal.tsx
+++ b/packages/ui-components/src/components/Domain/DomainListModal.tsx
@@ -81,7 +81,7 @@ export const DomainListModal = (props: ModalProps) => {
       noContentPadding
     >
       {props.subtitle && (
-        <Box display="flex" width="100%" justifyItems="left">
+        <Box display="flex" width="100%" justifyItems="left" maxWidth="400px">
           <Typography variant="body2">{props.subtitle}</Typography>
         </Box>
       )}

--- a/packages/ui-components/src/locales/en.json
+++ b/packages/ui-components/src/locales/en.json
@@ -580,6 +580,7 @@
     "loadingYourChat": "Joining chat...",
     "loadingYourChatDescription": "The group chat is being updated with your encryption keys to enable end-to-end encryption between members.",
     "memberCount": "Members ({{count}})",
+    "memberCountDescription": "Members in this list have access to messages sent to the {{name}} group chat",
     "messages": "Messages",
     "messagingAvailable": "Unstoppable Messaging available for setup",
     "messagingEnabled": "Unstoppable Messaging enabled",


### PR DESCRIPTION
## Screenshot
### Horizontal options menu to right of each chat
Displayed on mouseover

<img width="436" alt="image" src="https://github.com/unstoppabledomains/domain-profiles/assets/21039114/2de5c4a0-9034-48f9-aef4-e8b0ccc808d4">
