### PR TITLE
Group chat tab with dynamic preview and sorting

### DIFF
--- a/packages/ui-components/CHANGELOG.md
+++ b/packages/ui-components/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## 0.0.39
+
+- Group chat dynamic preview and sorting
+- Improved styling for group chat media
+
 ## 0.0.38
 
 - Group chat emoji reaction support

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unstoppabledomains/ui-components",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "private": true,
   "description": "An open and reusable suite of Unstoppable Domains management components",
   "keywords": [

--- a/packages/ui-components/src/components/Chat/modal/ChatModal.tsx
+++ b/packages/ui-components/src/components/Chat/modal/ChatModal.tsx
@@ -1007,6 +1007,7 @@ export const ChatModal: React.FC<ChatModalProps> = ({
                       domain={authDomain}
                       pushKey={pushKey}
                       searchTerm={searchValue}
+                      incomingMessage={incomingGroup}
                       setActiveCommunity={setActiveCommunity}
                     />
                   ) : (

--- a/packages/ui-components/src/components/Chat/modal/group/Community.tsx
+++ b/packages/ui-components/src/components/Chat/modal/group/Community.tsx
@@ -4,6 +4,7 @@ import GroupsIcon from '@mui/icons-material/GroupOutlined';
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
 import LogoutIcon from '@mui/icons-material/Logout';
 import MoreVertOutlinedIcon from '@mui/icons-material/MoreVertOutlined';
+import ShareOutlinedIcon from '@mui/icons-material/ShareOutlined';
 import Avatar from '@mui/material/Avatar';
 import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
@@ -19,6 +20,7 @@ import Typography from '@mui/material/Typography';
 import {styled} from '@mui/material/styles';
 import type {GroupDTO, IMessageIPFS} from '@pushprotocol/restapi';
 import Bluebird from 'bluebird';
+import {useSnackbar} from 'notistack';
 import type {MouseEvent} from 'react';
 import React, {useEffect, useState} from 'react';
 import InfiniteScroll from 'react-infinite-scroll-component';
@@ -30,6 +32,8 @@ import {notifyError} from '../../../../lib/error';
 import useTranslationContext from '../../../../lib/i18n';
 import type {SerializedCryptoWalletBadge} from '../../../../lib/types/badge';
 import type {Web3Dependencies} from '../../../../lib/types/web3';
+import type {CopyModule} from '../../../CopyToClipboard';
+import {noop} from '../../../CopyToClipboard';
 import {DomainListModal} from '../../../Domain';
 import {
   PUSH_PAGE_SIZE,
@@ -65,6 +69,7 @@ export const Community: React.FC<CommunityProps> = ({
 }) => {
   const {classes} = useConversationStyles({isChatRequest: false});
   const [t] = useTranslationContext();
+  const {enqueueSnackbar} = useSnackbar();
   const [isLoading, setIsLoading] = useState(true);
   const [isMember, setIsMember] = useState(true);
   const [isLeaving, setIsLeaving] = useState(false);
@@ -192,12 +197,29 @@ export const Community: React.FC<CommunityProps> = ({
     });
   };
 
+  const handleClickToCopy = () => {
+    enqueueSnackbar(t('common.copied'), {variant: 'success'});
+  };
+
   const handleOpenMenu = (e: MouseEvent<HTMLElement>) => {
     setAnchorEl(e.currentTarget);
   };
 
   const handleCloseMenu = () => {
     setAnchorEl(null);
+  };
+
+  const handleShareInvite = () => {
+    void (import('clipboard-copy') as Promise<CopyModule>).then(
+      (mod: CopyModule) => {
+        mod
+          .default(
+            `${config.UD_ME_BASE_URL}/${authDomain}?openBadgeCode=${badge.code}&action=invite`,
+          )
+          .then(handleClickToCopy)
+          .catch(noop);
+      },
+    );
   };
 
   const handleLeaveChat = async () => {
@@ -407,6 +429,18 @@ export const Community: React.FC<CommunityProps> = ({
                   </Typography>
                 </MenuItem>
               )}
+              <MenuItem
+                onClick={() => {
+                  handleShareInvite();
+                }}
+              >
+                <ListItemIcon>
+                  <ShareOutlinedIcon fontSize="small" />
+                </ListItemIcon>
+                <Typography variant="body2">
+                  {t('push.shareInviteLink')}
+                </Typography>
+              </MenuItem>
               <MenuItem
                 onClick={async () => {
                   await handleLeaveChat();

--- a/packages/ui-components/src/components/Chat/modal/group/CommunityConversationBubble.tsx
+++ b/packages/ui-components/src/components/Chat/modal/group/CommunityConversationBubble.tsx
@@ -368,7 +368,7 @@ export const CommunityConversationBubble: React.FC<
               : classes.avatarContainer
           }
         >
-          {peerAvatarLink && peerDisplayName && (
+          {peerDisplayName && (
             <Box>
               <Tooltip title={peerDisplayName}>
                 <Avatar

--- a/packages/ui-components/src/components/Chat/modal/group/CommunityList.tsx
+++ b/packages/ui-components/src/components/Chat/modal/group/CommunityList.tsx
@@ -2,7 +2,7 @@ import Box from '@mui/material/Box';
 import CircularProgress from '@mui/material/CircularProgress';
 import Typography from '@mui/material/Typography';
 import type {Theme} from '@mui/material/styles';
-import type {GroupDTO} from '@pushprotocol/restapi';
+import type {GroupDTO, IMessageIPFS} from '@pushprotocol/restapi';
 import Bluebird from 'bluebird';
 import React, {useEffect, useState} from 'react';
 
@@ -57,6 +57,7 @@ export const CommunityList: React.FC<CommunityListProps> = ({
   domain,
   pushKey,
   searchTerm,
+  incomingMessage,
   setActiveCommunity,
 }) => {
   const {classes} = useStyles();
@@ -197,6 +198,7 @@ export const CommunityList: React.FC<CommunityListProps> = ({
               onReload={loadBadges}
               onRefresh={refreshBadges}
               searchTerm={searchTerm}
+              incomingMessage={incomingMessage}
               setActiveCommunity={setActiveCommunity}
               visible={!inGroup(badge.groupChatId) || isSorted}
             />
@@ -218,6 +220,7 @@ export type CommunityListProps = {
   domain: string;
   pushKey: string;
   searchTerm?: string;
+  incomingMessage?: IMessageIPFS;
   setActiveCommunity: (v: SerializedCryptoWalletBadge) => void;
 };
 

--- a/packages/ui-components/src/components/Chat/modal/styles.ts
+++ b/packages/ui-components/src/components/Chat/modal/styles.ts
@@ -60,6 +60,7 @@ export const useConversationBubbleStyles = makeStyles<{
     marginBottom: theme.spacing(0.5),
     marginLeft: theme.spacing(1),
     marginRight: theme.spacing(1),
+    zIndex: 1000,
   },
   reaction: {
     display: 'flex',
@@ -150,13 +151,13 @@ export const useConversationBubbleStyles = makeStyles<{
   },
   imageAttachmentRight: {
     borderRadius: theme.spacing(2.5, 2.5, 0, 2.5),
-    margin: theme.spacing(-1, -2, 0, -2),
+    margin: theme.spacing(-1, -2, -2, -2),
     cursor: 'pointer',
     maxWidth: '250px',
   },
   imageAttachmentLeft: {
     borderRadius: theme.spacing(2.5, 2.5, 2.5, 0),
-    margin: theme.spacing(-1, -2, 0, -2),
+    margin: theme.spacing(-1, -2, -2, -2),
     cursor: 'pointer',
     maxWidth: '250px',
   },

--- a/packages/ui-components/src/components/CopyToClipboard.tsx
+++ b/packages/ui-components/src/components/CopyToClipboard.tsx
@@ -2,7 +2,7 @@ import Box from '@mui/material/Box';
 import type {ReactNode} from 'react';
 import React from 'react';
 
-type CopyModule = {default: (text: string) => Promise<void>};
+export type CopyModule = {default: (text: string) => Promise<void>};
 
 export const noop = () => {};
 

--- a/packages/ui-components/src/locales/en.json
+++ b/packages/ui-components/src/locales/en.json
@@ -635,6 +635,7 @@
       "title": "Unstoppable Messaging",
       "yourWallet": "your wallet"
     },
+    "shareInviteLink": "Share invite",
     "showRequests": "View chat requests ({{count}})",
     "spamWarning": "Others have reported this sender as spam",
     "typeMessage": "Type your message...",


### PR DESCRIPTION
When viewing the list of member groups, incoming messages should dynamically update and re-order the list.

## Screenshot
<img width="436" alt="image" src="https://github.com/unstoppabledomains/domain-profiles/assets/21039114/5d4d0f43-ea62-4a03-b459-7c4892a94ac9">
