### PR TITLE
Initialize web3context provider for push account signing

### DIFF
--- a/packages/ui-components/src/components/Wallet/AccessEthereum.tsx
+++ b/packages/ui-components/src/components/Wallet/AccessEthereum.tsx
@@ -5,13 +5,14 @@ import type {Theme} from '@mui/material/styles';
 import type {GetWalletClientResult} from '@wagmi/core';
 import type {Signer} from 'ethers';
 import React, {useEffect, useState} from 'react';
-import type {Connector} from 'wagmi';
 import {useConnect, useDisconnect, useWalletClient} from 'wagmi';
+import type {Connector} from 'wagmi';
 
 import {makeStyles} from '@unstoppabledomains/ui-kit/styles';
 
 import WalletButton from '../../components/Wallet/WalletButton';
 import useTranslationContext from '../../lib/i18n';
+import {sleep} from '../../lib/sleep';
 import type {WagmiConnectorType, WalletName} from '../../lib/types/wallet';
 import {WalletOptions} from '../../lib/types/wallet';
 import type {Web3Dependencies} from '../../lib/types/web3';
@@ -48,6 +49,7 @@ const AccessEthereum: React.FC<AccessEthereumProps> = ({
   const {classes} = useStyles();
   const [t] = useTranslationContext();
   const [selectedWallet, setSelectedWallet] = useState<WalletName>();
+  const [selectedConnector, setSelectedConnector] = useState<Connector>();
 
   // wagmi hooks
   const {disconnect} = useDisconnect();
@@ -82,10 +84,12 @@ const AccessEthereum: React.FC<AccessEthereumProps> = ({
   }, [connectError]);
 
   const handleClick = async (walletName: WalletName, connector: Connector) => {
+    setSelectedConnector(connector);
     setSelectedWallet(walletName);
     for (let i = 0; i < 10; i++) {
       try {
         const connectedAddress = await connectAsync({connector});
+        await sleep(500);
         if (!connectedAddress || connectedSigner) {
           break;
         }
@@ -109,6 +113,7 @@ const AccessEthereum: React.FC<AccessEthereumProps> = ({
     onComplete({
       address,
       signer: walletClientSigner as unknown as Signer,
+      provider: await selectedConnector?.getProvider(),
     });
   };
 

--- a/packages/ui-components/src/lib/types/web3.ts
+++ b/packages/ui-components/src/lib/types/web3.ts
@@ -3,4 +3,6 @@ import type {Signer} from 'ethers';
 export interface Web3Dependencies {
   address: string;
   signer: Signer;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  provider?: any;
 }


### PR DESCRIPTION
There is an edge case in the way the `AccessWalletModal` creates a web3context signer. The provider needs to be initialized for older (v1) push protocol accounts.