### PR TITLE
Consume profile API attachment endpoint

### DIFF
--- a/packages/ui-components/src/components/Chat/modal/dm/ConversationCompose.tsx
+++ b/packages/ui-components/src/components/Chat/modal/dm/ConversationCompose.tsx
@@ -197,7 +197,7 @@ export const Compose: React.FC<ComposeProps> = ({
 
   // handleUploadFile transmits the selected file to remote storage
   const handleUploadFile = async () => {
-    if (conversation && uploadFile && storageApiKey) {
+    if (conversation && uploadFile && storageApiKey && authDomain) {
       try {
         // retrieve the attachment from device
         setIsSending(true);
@@ -206,7 +206,7 @@ export const Compose: React.FC<ComposeProps> = ({
         const sentMessage = await sendRemoteAttachment(
           conversation,
           uploadFile,
-          storageApiKey,
+          authDomain,
         );
         sendCallback(sentMessage);
         setErrorMessage('');
@@ -245,10 +245,13 @@ export const Compose: React.FC<ComposeProps> = ({
       <IconButton
         disableRipple={true}
         component="label"
+        disabled={!authDomain}
         onClick={() => setSignatureClicked(true)}
       >
         <input hidden type="file" onChange={handleUploadClicked} />
-        <AddCircleOutlineOutlinedIcon className={classes.attachIcon} />
+        <Tooltip title={!authDomain ? t('push.domainRequiredUpload') : ''}>
+          <AddCircleOutlineOutlinedIcon className={classes.attachIcon} />
+        </Tooltip>
       </IconButton>
       <InputBase
         id="textbox-input"

--- a/packages/ui-components/src/components/Chat/modal/group/CommunityCompose.tsx
+++ b/packages/ui-components/src/components/Chat/modal/group/CommunityCompose.tsx
@@ -205,7 +205,7 @@ export const CommunityCompose: React.FC<CommunityComposeProps> = ({
       return;
     }
 
-    if (uploadFile && storageApiKey) {
+    if (uploadFile && storageApiKey && authDomain) {
       try {
         // retrieve the attachment from device
         setIsSending(true);
@@ -215,7 +215,7 @@ export const CommunityCompose: React.FC<CommunityComposeProps> = ({
           chatId,
           address,
           pushKey,
-          storageApiKey,
+          authDomain,
           uploadFile,
         );
         sendCallback(sentMessage);

--- a/packages/ui-components/src/lib/types/domain.ts
+++ b/packages/ui-components/src/lib/types/domain.ts
@@ -183,6 +183,10 @@ export type RedditUserInfo = {
   totalKarma: number;
 } | null;
 
+export type SerializedAttachmentResponse = {
+  url: string;
+};
+
 export type SerializedBulkDomainResponse = {
   success: boolean;
   domains: string[];

--- a/packages/ui-components/src/locales/en.json
+++ b/packages/ui-components/src/locales/en.json
@@ -564,6 +564,7 @@
     "communitiesRequireADomain": "To start discovering groups you need to add a Web3 domain to this wallet.",
     "configure": "Enable Unstoppable Messaging on this device for {{domain}}",
     "decrypting": "Loading message...",
+    "domainRequiredUpload": "A domain is required to upload attachments",
     "dropToUpload": "Drop file to upload...",
     "emptyNotifications": "No App Notifications",
     "emptyNotificationsDescription": "Subscribe to an app channel to receive notifications like security alerts, crypto news and more.",


### PR DESCRIPTION
A profile API endpoint is available to handle both XMTP and Push Protocol attachment uploads. This PR migrates from the 3rd party storage provider (web3.storage) to the Unstoppable Domains hosted storage.