### PR TITLE
[ECW-3124] Use public domain sales endpoint at UD.me

### DIFF
--- a/packages/ui-components/src/actions/domainActions.ts
+++ b/packages/ui-components/src/actions/domainActions.ts
@@ -10,6 +10,7 @@ import type {
 import type {
   DomainCryptoVerificationBodyPOST,
   EnsDomainStatusResponse,
+  PublicDomainPrimarySalesByLabelResponse,
   SerializedDomainRank,
   SerializedTxns,
 } from '../lib/types/domain';
@@ -103,6 +104,12 @@ export const getEnsDomainStatus = async (
     method: 'GET',
   });
 };
+
+export const getPublicDomainPrimarySalesByLabel = async (label: string) =>
+  await fetchApi<PublicDomainPrimarySalesByLabelResponse>(
+    `/domain/primary-sales/labels/${label}`,
+    {headers: {'Content-Type': 'application/json'}},
+  );
 
 export const getStrictReverseResolution = async (
   address: string,

--- a/packages/ui-components/src/lib/types/domain.ts
+++ b/packages/ui-components/src/lib/types/domain.ts
@@ -177,6 +177,14 @@ export type MessagingAttributes = {
   thirdPartyMessagingConfigType: string;
 };
 
+export type PublicDomainPrimarySale = {
+  domainName: string;
+  price: number;
+  purchasedAt: string;
+};
+
+export type PublicDomainPrimarySalesByLabelResponse = PublicDomainPrimarySale[];
+
 export type RedditUserInfo = {
   kind: DomainProfileSocialMedia.Reddit;
   name: string;


### PR DESCRIPTION
This PR adds a new public domain sales data endpoint to be used at UD.me. Since the endpoint is rated limited to 30 req/minute/ip I decided to use the ecomm directly without proxying the request through the internal profile API:

<img width="659" alt="buymenow2 crypto | Unstoppable Domains 2024-02-14 19-00-04" src="https://github.com/unstoppabledomains/domain-profiles/assets/325422/7544e61d-5d1a-4982-8209-f27b523c8c3c">
