### PR TITLE
Enable address verification while on-chain records are pending

### DIFF
--- a/packages/ui-components/src/components/Manage/DomainProfileModal.tsx
+++ b/packages/ui-components/src/components/Manage/DomainProfileModal.tsx
@@ -10,7 +10,7 @@ import type {SerializedUserDomainProfileData} from '../../lib';
 import type {DomainProfileTabType} from './DomainProfile';
 import {DomainProfile} from './DomainProfile';
 
-const MODAL_WIDTH = '515px';
+const MODAL_WIDTH = '550px';
 
 const useStyles = makeStyles()((theme: Theme) => ({
   container: {

--- a/packages/ui-components/src/components/Manage/Tabs/Crypto.tsx
+++ b/packages/ui-components/src/components/Manage/Tabs/Crypto.tsx
@@ -53,8 +53,9 @@ const useStyles = makeStyles()((theme: Theme) => ({
     display: 'flex',
     marginTop: theme.spacing(1),
     padding: theme.spacing(1),
-    backgroundColor: theme.palette.primary.main,
+    backgroundImage: `linear-gradient(to left, ${theme.palette.primaryShades[400]}, ${theme.palette.primaryShades[600]})`,
     justifyContent: 'center',
+    borderRadius: theme.shape.borderRadius,
   },
   pendingTxText: {
     color: theme.palette.white,
@@ -86,6 +87,7 @@ export const Crypto: React.FC<CryptoProps> = ({address, domain, filterFn}) => {
   const {unsResolverKeys: resolverKeys, loading: resolverKeysLoading} =
     useResolverKeys();
   const [saveClicked, setSaveClicked] = useState(false);
+  const [isSignatureSuccess, setIsSignatureSuccess] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [isSaving, setIsSaving] = useState(false);
   const [isPendingTx, setIsPendingTx] = useState<boolean>();
@@ -158,6 +160,7 @@ export const Crypto: React.FC<CryptoProps> = ({address, domain, filterFn}) => {
             // record updates successful
             setIsSaving(false);
             setIsPendingTx(true);
+            setIsSignatureSuccess(true);
             return;
           }
         }
@@ -285,6 +288,7 @@ export const Crypto: React.FC<CryptoProps> = ({address, domain, filterFn}) => {
         profileData={profileData}
         uiDisabled={!!isPendingTx}
         setWeb3Deps={setWeb3Deps}
+        saveClicked={isSignatureSuccess}
       />
     ));
   };
@@ -306,6 +310,7 @@ export const Crypto: React.FC<CryptoProps> = ({address, domain, filterFn}) => {
           uiDisabled={!!isPendingTx}
           profileData={profileData}
           setWeb3Deps={setWeb3Deps}
+          saveClicked={isSignatureSuccess}
         />
       );
     });

--- a/packages/ui-components/src/components/Manage/Tabs/Reverse.tsx
+++ b/packages/ui-components/src/components/Manage/Tabs/Reverse.tsx
@@ -68,8 +68,9 @@ const useStyles = makeStyles()((theme: Theme) => ({
     display: 'flex',
     marginTop: theme.spacing(1),
     padding: theme.spacing(1),
-    backgroundColor: theme.palette.primary.main,
+    backgroundImage: `linear-gradient(to left, ${theme.palette.primaryShades[400]}, ${theme.palette.primaryShades[600]})`,
     justifyContent: 'center',
+    borderRadius: theme.shape.borderRadius,
   },
   pendingTxText: {
     color: theme.palette.white,

--- a/packages/ui-components/src/components/Manage/common/CurrencyInput.tsx
+++ b/packages/ui-components/src/components/Manage/common/CurrencyInput.tsx
@@ -33,6 +33,7 @@ export interface Props {
   uiDisabled: boolean;
   profileData?: SerializedPublicDomainProfileData;
   setWeb3Deps: (value: Web3Dependencies | undefined) => void;
+  saveClicked: boolean;
 }
 
 export const useStyles = makeStyles()((theme: Theme) => ({
@@ -229,6 +230,7 @@ const CurrencyInput: React.FC<Props> = ({
   uiDisabled,
   profileData,
   setWeb3Deps,
+  saveClicked,
 }) => {
   const [t] = useTranslationContext();
   const {classes} = useStyles();
@@ -318,7 +320,8 @@ const CurrencyInput: React.FC<Props> = ({
           profileData={profileData}
           currency={currency}
           setWeb3Deps={setWeb3Deps}
-          uiDisabled={uiDisabled}
+          uiDisabled={false}
+          saveClicked={saveClicked}
         />
       }
     />

--- a/packages/ui-components/src/components/Manage/common/MultiChainInput.tsx
+++ b/packages/ui-components/src/components/Manage/common/MultiChainInput.tsx
@@ -32,6 +32,7 @@ type Props = {
   profileData?: SerializedPublicDomainProfileData;
   uiDisabled: boolean;
   setWeb3Deps: (value: Web3Dependencies | undefined) => void;
+  saveClicked: boolean;
 };
 
 const MultiChainInput: React.FC<Props> = ({
@@ -44,6 +45,7 @@ const MultiChainInput: React.FC<Props> = ({
   profileData,
   uiDisabled,
   setWeb3Deps,
+  saveClicked,
 }) => {
   const [t] = useTranslationContext();
   const {classes} = useStyles();
@@ -155,7 +157,8 @@ const MultiChainInput: React.FC<Props> = ({
                           profileData={profileData}
                           currency={currency}
                           setWeb3Deps={setWeb3Deps}
-                          uiDisabled={uiDisabled}
+                          uiDisabled={false}
+                          saveClicked={saveClicked}
                         />
                       }
                     />

--- a/packages/ui-components/src/components/Manage/common/TabHeader.tsx
+++ b/packages/ui-components/src/components/Manage/common/TabHeader.tsx
@@ -17,7 +17,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
     minHeight: AVATAR_PLACEHOLDER_SIZE,
   },
   headerContainer: {
-    backgroundColor: '#192B55',
+    backgroundImage: `linear-gradient(to left, #192b55c0, #192B55)`,
     borderTopRightRadius: theme.shape.borderRadius,
     borderTopLeftRadius: theme.shape.borderRadius,
     color: theme.palette.white,

--- a/packages/ui-components/src/components/Manage/common/verification/VerificationInfoModal.tsx
+++ b/packages/ui-components/src/components/Manage/common/verification/VerificationInfoModal.tsx
@@ -9,12 +9,14 @@ import IconButton from '@mui/material/IconButton';
 import Tab from '@mui/material/Tab';
 import Typography from '@mui/material/Typography';
 import type {Theme} from '@mui/material/styles';
-import React, {useState} from 'react';
+import React, {useEffect, useState} from 'react';
 import truncateEthAddress from 'truncate-eth-address';
 
 import {makeStyles} from '@unstoppabledomains/ui-kit/styles';
 
+import {useWeb3Context} from '../../../../hooks';
 import {useTranslationContext} from '../../../../lib';
+import {notifyEvent} from '../../../../lib/error';
 import CopyToClipboard from '../../../CopyToClipboard';
 import Link from '../../../Link';
 import {getBlockchainName} from './types';
@@ -80,6 +82,20 @@ const VerificationInfoModal: React.FC<Props> = ({
   const [t] = useTranslationContext();
   const {classes} = useStyles();
   const [tabValue, setTabValue] = useState(tabType.Sign);
+  const {setWeb3Deps} = useWeb3Context();
+
+  useEffect(() => {
+    try {
+      // always disconnect wallet when loading the verification modal, because
+      // the user needs the ability to change their connected wallet to match
+      // the crypto address record.
+      if (setWeb3Deps) {
+        setWeb3Deps(undefined);
+      }
+    } catch (e) {
+      notifyEvent(e, 'warning', 'WALLET', 'Signature');
+    }
+  }, [setWeb3Deps]);
 
   const handleClickDelegate = async () => {
     window.open(

--- a/packages/ui-components/src/components/Manage/common/verification/VerifyAdornment.tsx
+++ b/packages/ui-components/src/components/Manage/common/verification/VerifyAdornment.tsx
@@ -47,6 +47,7 @@ export type Props = {
   uiDisabled: boolean;
   profileData?: SerializedPublicDomainProfileData;
   setWeb3Deps: (value: Web3Dependencies | undefined) => void;
+  saveClicked: boolean;
 };
 
 const VerifyAdornment: React.FC<Props> = ({
@@ -55,6 +56,7 @@ const VerifyAdornment: React.FC<Props> = ({
   domain,
   ownerAddress,
   profileData,
+  saveClicked,
   uiDisabled,
   setWeb3Deps,
 }) => {
@@ -116,7 +118,8 @@ const VerifyAdornment: React.FC<Props> = ({
     return (
       <div className={classes.unverifiedBlock}>
         {addressCurrent &&
-          (addressCurrent === addressOriginal && !uiDisabled ? (
+          ((addressCurrent === addressOriginal || saveClicked) &&
+          !uiDisabled ? (
             getVerificationProvider({
               ownerAddress,
               address: addressCurrent,

--- a/packages/ui-components/src/components/Wallet/TokensPortfolio.tsx
+++ b/packages/ui-components/src/components/Wallet/TokensPortfolio.tsx
@@ -349,6 +349,7 @@ export const TokensPortfolio: React.FC<TokensPortfolioProps> = ({
           [classes.walletContainerSelected]: filterAddress === wallet,
         })}
         onClick={() => setFilterAddress(wallet)}
+        key={`wallet-${wallet?.symbol}-${wallet?.address}`}
       >
         {wallet ? (
           <>

--- a/packages/ui-components/src/locales/en.json
+++ b/packages/ui-components/src/locales/en.json
@@ -332,7 +332,7 @@
     },
     "verified": "Verified",
     "verify": "Verify",
-    "verifyAfterConfirm": "You can verify this {{currency}} address after changes are confirmed on-chain.",
+    "verifyAfterConfirm": "You can verify this {{currency}} address after changes are saved.",
     "visibleToEveryone": "Visible to everyone",
     "walletAddressIncorrect": "Cannot verify address {{address}} with connected wallet {{connectedAddress}}. Switch the wallet account and try again.",
     "walletNotConnected": "Unable to connect with {{extension}} wallet. Ensure the browser extension is installed and try again.",


### PR DESCRIPTION
Instead of waiting for on-chain records to be confirmed (up to several minutes) to verify a crypto address, allow the user to verify while they wait for confirmation. Much smoother user experience, which is now enabled by new backend logic.