### PR TITLE
Only display on-chain actions for UNS domains on Polygon blockchain

### DIFF
--- a/packages/ui-components/src/components/Manage/DomainProfile.tsx
+++ b/packages/ui-components/src/components/Manage/DomainProfile.tsx
@@ -98,6 +98,7 @@ const StyledTabBadge = styled(Badge)<BadgeProps>(() => ({
 export const DomainProfile: React.FC<DomainProfileProps> = ({
   address,
   domain,
+  metadata,
   width,
   onClose,
   onUpdate,
@@ -121,6 +122,9 @@ export const DomainProfile: React.FC<DomainProfileProps> = ({
     listForSale: false,
     website: false,
   });
+  const isOnchainSupported =
+    (metadata.type as string)?.toLowerCase() === 'uns' &&
+    (metadata.blockchain as string)?.toLowerCase() === 'matic';
 
   const handleTabChange = (event: React.SyntheticEvent, newValue: string) => {
     const tv = newValue as DomainProfileTabType;
@@ -165,51 +169,57 @@ export const DomainProfile: React.FC<DomainProfileProps> = ({
                   }
                   value={DomainProfileTabType.Profile}
                 />
-                <Tab
-                  label={
-                    <StyledTabBadge
-                      color="primary"
-                      variant="dot"
-                      invisible={!tabUnreadDot[DomainProfileTabType.Crypto]}
-                    >
-                      <Box className={classes.tabLabel}>
-                        {' '}
-                        {t('manage.crypto')}
-                      </Box>
-                    </StyledTabBadge>
-                  }
-                  disabled={isExternalDomain(domain)}
-                  value={DomainProfileTabType.Crypto}
-                />
-                <Tab
-                  label={
-                    <StyledTabBadge
-                      color="primary"
-                      variant="dot"
-                      invisible={!tabUnreadDot[DomainProfileTabType.Reverse]}
-                    >
-                      <Box className={classes.tabLabel}>
-                        {t('manage.reverse')}
-                      </Box>
-                    </StyledTabBadge>
-                  }
-                  disabled={isExternalDomain(domain)}
-                  value={DomainProfileTabType.Reverse}
-                />
-                <Tab
-                  label={
-                    <StyledTabBadge
-                      color="primary"
-                      variant="dot"
-                      invisible={!tabUnreadDot[DomainProfileTabType.Website]}
-                    >
-                      <Box className={classes.tabLabel}>
-                        {t('manage.web3Website')}
-                      </Box>
-                    </StyledTabBadge>
-                  }
-                  value={DomainProfileTabType.Website}
-                />
+                {isOnchainSupported && (
+                  <Tab
+                    label={
+                      <StyledTabBadge
+                        color="primary"
+                        variant="dot"
+                        invisible={!tabUnreadDot[DomainProfileTabType.Crypto]}
+                      >
+                        <Box className={classes.tabLabel}>
+                          {' '}
+                          {t('manage.crypto')}
+                        </Box>
+                      </StyledTabBadge>
+                    }
+                    disabled={isExternalDomain(domain)}
+                    value={DomainProfileTabType.Crypto}
+                  />
+                )}
+                {isOnchainSupported && (
+                  <Tab
+                    label={
+                      <StyledTabBadge
+                        color="primary"
+                        variant="dot"
+                        invisible={!tabUnreadDot[DomainProfileTabType.Reverse]}
+                      >
+                        <Box className={classes.tabLabel}>
+                          {t('manage.reverse')}
+                        </Box>
+                      </StyledTabBadge>
+                    }
+                    disabled={isExternalDomain(domain)}
+                    value={DomainProfileTabType.Reverse}
+                  />
+                )}
+                {isOnchainSupported && (
+                  <Tab
+                    label={
+                      <StyledTabBadge
+                        color="primary"
+                        variant="dot"
+                        invisible={!tabUnreadDot[DomainProfileTabType.Website]}
+                      >
+                        <Box className={classes.tabLabel}>
+                          {t('manage.web3Website')}
+                        </Box>
+                      </StyledTabBadge>
+                    }
+                    value={DomainProfileTabType.Website}
+                  />
+                )}
                 <Tab
                   label={
                     <StyledTabBadge
@@ -270,21 +280,23 @@ export const DomainProfile: React.FC<DomainProfileProps> = ({
                   }
                   value={DomainProfileTabType.ListForSale}
                 />
-                <Tab
-                  label={
-                    <StyledTabBadge
-                      color="primary"
-                      variant="dot"
-                      invisible={!tabUnreadDot[DomainProfileTabType.Transfer]}
-                    >
-                      <Box className={classes.tabLabel}>
-                        {t('manage.transfer')}
-                      </Box>
-                    </StyledTabBadge>
-                  }
-                  disabled={isExternalDomain(domain)}
-                  value={DomainProfileTabType.Transfer}
-                />
+                {isOnchainSupported && (
+                  <Tab
+                    label={
+                      <StyledTabBadge
+                        color="primary"
+                        variant="dot"
+                        invisible={!tabUnreadDot[DomainProfileTabType.Transfer]}
+                      >
+                        <Box className={classes.tabLabel}>
+                          {t('manage.transfer')}
+                        </Box>
+                      </StyledTabBadge>
+                    }
+                    disabled={isExternalDomain(domain)}
+                    value={DomainProfileTabType.Transfer}
+                  />
+                )}
               </TabList>
             </Box>
           </Box>
@@ -399,6 +411,7 @@ export type DomainProfileProps = {
   address: string;
   domain: string;
   width: string;
+  metadata: Record<string, string | boolean>;
   onClose?: () => void;
   onUpdate(
     tab: DomainProfileTabType,

--- a/packages/ui-components/src/components/Manage/DomainProfile.tsx
+++ b/packages/ui-components/src/components/Manage/DomainProfile.tsx
@@ -123,6 +123,7 @@ export const DomainProfile: React.FC<DomainProfileProps> = ({
     website: false,
   });
   const isOnchainSupported =
+    !isExternalDomain(domain) &&
     (metadata.type as string)?.toLowerCase() === 'uns' &&
     (metadata.blockchain as string)?.toLowerCase() === 'matic';
 
@@ -183,7 +184,6 @@ export const DomainProfile: React.FC<DomainProfileProps> = ({
                         </Box>
                       </StyledTabBadge>
                     }
-                    disabled={isExternalDomain(domain)}
                     value={DomainProfileTabType.Crypto}
                   />
                 )}
@@ -200,7 +200,6 @@ export const DomainProfile: React.FC<DomainProfileProps> = ({
                         </Box>
                       </StyledTabBadge>
                     }
-                    disabled={isExternalDomain(domain)}
                     value={DomainProfileTabType.Reverse}
                   />
                 )}
@@ -293,7 +292,6 @@ export const DomainProfile: React.FC<DomainProfileProps> = ({
                         </Box>
                       </StyledTabBadge>
                     }
-                    disabled={isExternalDomain(domain)}
                     value={DomainProfileTabType.Transfer}
                   />
                 )}

--- a/packages/ui-components/src/locales/en.json
+++ b/packages/ui-components/src/locales/en.json
@@ -300,6 +300,7 @@
     "listForSaleEmail": "Email",
     "location": "Location",
     "mainInfo": "Main Info",
+    "manageDomainModalOpenError": "Error opening domain management window",
     "manageProfile": "Manage",
     "onlyYouAndDapps": "Only you and allowed dApps",
     "overwriteExistingReverseResolution": "After the update, {{domain}} will no longer be your primary name for this wallet.",

--- a/server/pages/[domain]/index.page.tsx
+++ b/server/pages/[domain]/index.page.tsx
@@ -311,6 +311,14 @@ const DomainProfile = ({
     }
   };
 
+  const handleManageDomainModalOpen = async () => {
+    if (profileData?.metadata) {
+      setShowManageDomainModal(true);
+      return;
+    }
+    enqueueSnackbar(t('manage.manageDomainModalOpenError'), {variant: 'error'});
+  };
+
   const handleManageDomainModalClose = async () => {
     setShowManageDomainModal(false);
     if (isReloadRequested) {
@@ -710,7 +718,7 @@ const DomainProfile = ({
                 ) : (
                   <ChipControlButton
                     data-testid="edit-profile-button"
-                    onClick={() => setShowManageDomainModal(true)}
+                    onClick={handleManageDomainModalOpen}
                     icon={<EditOutlinedIcon />}
                     label={t('manage.manageProfile')}
                   />

--- a/server/pages/[domain]/index.page.tsx
+++ b/server/pages/[domain]/index.page.tsx
@@ -1439,10 +1439,11 @@ const DomainProfile = ({
           onClose={handleOtherDomainsModalClose}
         />
       )}
-      {showManageDomainModal && (
+      {showManageDomainModal && profileData?.metadata && (
         <DomainProfileModal
           domain={domain}
           address={ownerAddress}
+          metadata={profileData.metadata}
           open={showManageDomainModal}
           onClose={handleManageDomainModalClose}
           onUpdate={handleManageDomainModalUpdate}


### PR DESCRIPTION
On the domain management modal, we should only show on-chain actions for UNS domains that are living on the Polygon blockchain. These are the domains currently supported by Partner API v3. At a point in the future, more domains will be added to this supported user experience.