### PR TITLE
[SRE-1475] update GCS Bucket

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -55,6 +55,9 @@ substitutions:
   _SERVICE_NAME: ud-me-stag
   _BUGSNAG_API_KEY: 4a72fb23d3ddc00054db744c3006f0cd
   _GATEWAY_API_KEY_SECRET: kong_consumer_stag_ud-me:1
+  _GCS_STORAGE_BUCKET_FOR_CLOUDBUILD: "ud-staging-cloudbuild-logs"
+logsBucket: "$_GCS_STORAGE_BUCKET_FOR_CLOUDBUILD"
+
 tags:
   - gcp-cloud-build-deploy-cloud-run
   - gcp-cloud-build-deploy-cloud-run-managed


### PR DESCRIPTION
GCP is chaning how cloudbuild uses service accounts, so we needed to update all of our cloudbuild triggers to run as a custom service accounts. https://github.com/unstoppabledomains/infrastructure/pull/316 did this.

however, when setting service accounts, a GCS bucket needs used to store logs. need to fix/update all the cloudbuild triggers and .yaml's

https://github.com/unstoppabledomains/infrastructure/pull/325 set the production value for the GCS bucket.

This PR sets the default / staging value.


SRE-1475
https://linear.app/unstoppable-domains/issue/SRE-1475/update-cloudbuild-to-use-new-gcs-buckest


Testing:
staging cloudbuild https://console.cloud.google.com/cloud-build/builds;region=us-central1/ea3e9260-7085-4248-8a5e-d39a730d461c?project=unstoppable-domains-staging shows that logs are being properly written to ud-staging-cloudbuild-logs
raw logs link shows this as truehttps://ffdccbbc8a4ec9ab9c68ae05ef28ddb0a371051a7227ad26af3c73b-apidata.googleusercontent.com/download/storage/v1/b/ud-staging-cloudbuild-logs/o/log-ea3e9260-7085-4248-8a5e-d39a730d461c.txt<truncated>

initiated production build https://console.cloud.google.com/cloud-build/builds;region=us-central1/d1c3b710-d64f-4612-8bc4-8187480cfd70?project=unstoppable-domains to confirm logs were being written to the ud-production-cloudbuild-logs GCS bucket (this execution was cancelled before anything actually "happened" during the build.

raw logs link shows this as true: https://ff10f8735a72a4dbfd8321796e5a89943ee011e529d2a1c31134574-apidata.googleusercontent.com/download/storage/v1/b/ud-production-cloudbuild-logs/o/log-d1c3b710-d64f-4612-8bc4-8187480cfd70.txt<truncated>

