### PR TITLE
Include Base blockchain icon

### DIFF
--- a/packages/ui-components/src/components/Image/BaseIcon.tsx
+++ b/packages/ui-components/src/components/Image/BaseIcon.tsx
@@ -1,0 +1,29 @@
+import type {SvgIconProps} from '@mui/material/SvgIcon';
+import SvgIcon from '@mui/material/SvgIcon';
+import React from 'react';
+
+const BaseIcon = React.forwardRef<
+  SVGSVGElement,
+  {
+    iconRef?: React.ForwardedRef<SVGSVGElement>;
+  } & SvgIconProps
+>(({iconRef, ...props}, ref) => {
+  return (
+    <SvgIcon viewBox="0 0 146 146" {...props} ref={iconRef || ref}>
+      <circle
+        xmlns="http://www.w3.org/2000/svg"
+        cx="73"
+        cy="73"
+        r="73"
+        fill="#0052FF"
+      />
+      <path
+        xmlns="http://www.w3.org/2000/svg"
+        d="M73.323 123.729C101.617 123.729 124.553 100.832 124.553 72.5875C124.553 44.343 101.617 21.4463 73.323 21.4463C46.4795 21.4463 24.4581 42.0558 22.271 68.2887H89.9859V76.8864H22.271C24.4581 103.119 46.4795 123.729 73.323 123.729Z"
+        fill="white"
+      />
+    </SvgIcon>
+  );
+});
+
+export default BaseIcon;

--- a/packages/ui-components/src/components/Image/CryptoIcon.tsx
+++ b/packages/ui-components/src/components/Image/CryptoIcon.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 import type {CurrenciesType} from '../../lib/types/blockchain';
 import {Currencies} from '../../lib/types/blockchain';
 
+const Base = dynamic(() => import('./BaseIcon'));
 const Bitcoin = dynamic(
   () => import('@unstoppabledomains/ui-kit/icons/crypto/Bitcoin'),
 );
@@ -428,6 +429,8 @@ type Props = {
 export const CryptoIcon = React.forwardRef<SVGSVGElement, Props>(
   ({currency, ...rest}, ref) => {
     switch (currency) {
+      case Currencies.BASE:
+        return <Base {...rest} fr={undefined} iconRef={ref} />;
       case Currencies.BTC:
         return <Bitcoin {...rest} fr={undefined} iconRef={ref} />;
       case Currencies.ETH:

--- a/packages/ui-components/src/components/Image/index.ts
+++ b/packages/ui-components/src/components/Image/index.ts
@@ -1,3 +1,4 @@
 export * from './CryptoIcon';
+export {default as BaseIcon} from './BaseIcon';
 export {default as LensIcon} from './LensIcon';
 export {default as Logo} from './Logo';

--- a/packages/ui-components/src/lib/types/blockchain.ts
+++ b/packages/ui-components/src/lib/types/blockchain.ts
@@ -146,6 +146,7 @@ export enum AdditionalCurrenciesEnum {
   VERSE = 'VERSE',
   ADA = 'ADA',
   HBAR = 'HBAR',
+  BASE = 'BASE',
 }
 
 export enum AllInitialCurrenciesEnum {


### PR DESCRIPTION
SVG definition from Base [brand kit](https://github.com/base-org/brand-kit/tree/7d3531058f5d89aeb627ab2045e1c5df3efb5de8).

## Screenshot
<img width="843" alt="image" src="https://github.com/unstoppabledomains/domain-profiles/assets/21039114/49561751-a063-437f-b516-c5186ce737be">
