### PR TITLE
Clarify crypto address action UX

### DIFF
--- a/packages/ui-components/src/locales/en.json
+++ b/packages/ui-components/src/locales/en.json
@@ -491,7 +491,6 @@
     "yourNftGalleryIsReadyToLaunch": "Your NFT gallery is ready to launch"
   },
   "profile": {
-    "buyCrypto": "Buy & sell crypto",
     "addressCount": "{{count}} Crypto addresses",
     "addressNotVerifiedMessageOwner": "Your {{symbol}} NFTs are not currently visible to other users. Verify your {{symbol}} address to unlock the NFT gallery.",
     "addressNotVerifiedMessagePublic": "NFTs displayed in the {{symbol}} gallery may not belong to the owner of this domain. Proceed with caution.",
@@ -499,6 +498,7 @@
     "badge": "badge",
     "badges": "Badges",
     "badgesAreSyncedFromDomainOwnerWallet": "Badges are synced from domain owner wallet: {{address}}",
+    "buyCrypto": "Buy & sell crypto",
     "clickToViewPortfolio": "Browse portfolio",
     "collapse": "Collapse",
     "collectingYourBadges": "Collecting your badges...",
@@ -555,6 +555,7 @@
       "to": "To"
     },
     "moreInformation": "More",
+    "openAddress": "Open in OKLink",
     "openSea": "OpenSea",
     "otherDomains": "{{count}} Other domains",
     "ownerAddress": "Owned by {{address}}",
@@ -590,6 +591,7 @@
     "verifiedWithUd": "Verified with UD",
     "verifyAddress": "Verify {{symbol}} address",
     "verifyWalletAddress": "Verify your wallet address",
+    "viewAddress": "View all addresses",
     "viewMyProfile": "My profile",
     "viewProfile": "View Profile",
     "website": "Website"

--- a/server/pages/[domain]/index.page.tsx
+++ b/server/pages/[domain]/index.page.tsx
@@ -1239,7 +1239,16 @@ const DomainProfile = ({
             <Grid container spacing={2}>
               <Grid item xs={12} md={6}>
                 <TokensPortfolio
-                  wallets={walletBalances}
+                  wallets={walletBalances
+                    ?.filter(
+                      w =>
+                        (w.totalValueUsdAmt && w.totalValueUsdAmt > 0) ||
+                        (w.txns?.data && w.txns.data.length > 0),
+                    )
+                    .sort(
+                      (a, b) =>
+                        (b.totalValueUsdAmt || 0) - (a.totalValueUsdAmt || 0),
+                    )}
                   domain={domain}
                   isOwner={isOwner}
                   isError={isWalletBalanceError}


### PR DESCRIPTION
Clarify the UX around the expected result of clicking a crypto icon chip on a domain profile page. Currently, all chips show a "copy icon" even though this may not be the action performed. This PR updates the chip as follows:

1. For supported single address records
   - Change to a "launch" styled icon
   - Add tooltip "Open in OKLink"
   - Clicking the chip results in a new browser tab opening the address in blockscan explorer
1. For supported multi address records
   - Change to a "menu" icon as the chip icon, to indicate options are available
   - Show the "launch icon" within the opened menu
   - Clicking the menu item results in a new browser tab opening the address in blockscan explorer
1. For unsupported chains
   - Keep the "copy" icon
   - Keep existing copy behavior

## Screenshots
### Single address record
The launch icon shows that clicking the chip will open a new window.

![telegram-cloud-photo-size-1-4911430356247358659-x](https://github.com/unstoppabledomains/domain-profiles/assets/21039114/d9b1b41c-9f44-4833-bd88-bc2260359bfa)

### Multi address record
The main menu item shows that more options are available. The launch icon indicates that clicking the menu item will result in opening a new window.

![telegram-cloud-photo-size-1-4911430356247358660-x](https://github.com/unstoppabledomains/domain-profiles/assets/21039114/bf16b9d4-e5fe-4b55-87df-ac40a8b4337f)

### Unsupported record
No change in behavior. Copy icon is retained, and the address is copied to clipboard when clicked.

![telegram-cloud-photo-size-1-4911430356247358661-x](https://github.com/unstoppabledomains/domain-profiles/assets/21039114/7b505160-d057-4326-8ada-1c4cd5889b1b)
