### PR TITLE
Open management modal with query string flag

### DIFF
--- a/packages/ui-components/src/lib/types/domain.ts
+++ b/packages/ui-components/src/lib/types/domain.ts
@@ -173,6 +173,8 @@ export type LinkedinUserInfo = {
 
 export const MANAGEABLE_DOMAIN_LABEL = /^[a-z\d-]{1,253}$/;
 
+export const MANAGE_DOMAIN_PARAM = 'manage';
+
 export const MAX_BIO_LENGTH = 200;
 
 export const MAX_UPLOAD_FILE_SIZE = 5 * 1000 * 1024;
@@ -524,7 +526,6 @@ export type TwitterUserInfo = {
   listedCount: number;
   tweetsCount: number;
 } | null;
-
 export const UD_BLUE_BADGE_CODE = 'UdBlue';
 
 export enum Web2Suffixes {

--- a/server/pages/[domain]/index.page.tsx
+++ b/server/pages/[domain]/index.page.tsx
@@ -36,6 +36,7 @@ import {normalizeIpfsHash} from 'lib/ipfs';
 import {shuffle} from 'lodash';
 import type {GetServerSideProps} from 'next';
 import {NextSeo} from 'next-seo';
+import {useRouter} from 'next/router';
 import {useSnackbar} from 'notistack';
 import numeral from 'numeral';
 import QueryString from 'qs';
@@ -78,6 +79,7 @@ import {
   LoginButton,
   LoginMethod,
   Logo,
+  MANAGE_DOMAIN_PARAM,
   NFTGalleryCarousel,
   ProfilePicture,
   ProfileSearchBar,
@@ -134,6 +136,7 @@ const DomainProfile = ({
   const {classes, cx} = useStyles();
   const isMounted = useIsMounted();
   const theme = useTheme();
+  const {query} = useRouter();
   const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
   const [imagePath, setImagePath] = useState<string>();
   const {enqueueSnackbar} = useSnackbar();
@@ -333,7 +336,7 @@ const DomainProfile = ({
     }
   };
 
-  const handleManageDomainModalOpen = async () => {
+  const handleManageDomainModalOpen = () => {
     if (profileData?.metadata) {
       setShowManageDomainModal(true);
       return;
@@ -388,6 +391,15 @@ const DomainProfile = ({
     walletBalances;
 
   useEffect(() => {
+    if (!query || !profileData) {
+      return;
+    }
+    if (query[MANAGE_DOMAIN_PARAM] !== undefined) {
+      handleManageDomainModalOpen();
+    }
+  }, [query, profileData]);
+
+  useEffect(() => {
     // wait until mounted
     if (!isMounted() || !isFeatureFlagSuccess || !ownerAddress) {
       return;
@@ -417,16 +429,6 @@ const DomainProfile = ({
   }, [isMounted, isFeatureFlagSuccess, featureFlags, ownerAddress]);
 
   useEffect(() => {
-    // report the initial page load
-    notifyEvent(
-      'loading profile page',
-      'info',
-      'PROFILE',
-      'Info',
-      undefined,
-      true,
-    );
-
     // determine social account status
     if (profileData?.socialAccounts) {
       setIsSomeSocialsPublic(


### PR DESCRIPTION
If the `manage` query string parameter is present, open the domain management modal on page load. If the user is not already logged in, they will be prompted to connect the appropriate wallet.