### PR TITLE
Validate domain preview fallback image

### DIFF
--- a/packages/ui-components/src/components/Domain/DomainPreview.tsx
+++ b/packages/ui-components/src/components/Domain/DomainPreview.tsx
@@ -158,12 +158,23 @@ export const DomainPreview: React.FC<DomainPreviewProps> = ({
   };
 
   const handleImgError = (e: React.SyntheticEvent<HTMLImageElement, Event>) => {
-    e.currentTarget.src =
+    // determine what fallback image should be used if the requested image fails
+    // to load, which depends on the type of domain.
+    const fallbackImgUrl =
       extension === DomainSuffixes.Ens
         ? getImageUrl('/domains/ens-logo.svg')
         : Web2SuffixesList.includes(extension)
         ? getImageUrl('/domains/dns-logo.svg')
         : `${config.UNSTOPPABLE_METADATA_ENDPOINT}/image-src/${domain}?withOverlay=false`;
+
+    // ensure the fallback image is different from the image that already failed
+    if (fallbackImgUrl.toLowerCase() === e.currentTarget.src.toLowerCase()) {
+      e.currentTarget.src = '';
+      return;
+    }
+
+    // set the fallback image
+    e.currentTarget.src = fallbackImgUrl;
   };
 
   return (


### PR DESCRIPTION
The `DomainPreview` component is widely used on profile pages to show a PFP image for a domain. There is image `onError` handling existing in the component, which does not properly handle the case where a fallback image does not properly load. If the fallback image doesn't load, the component will continually try to request the failing fallback image.