### PR TITLE
Ability to cancel pending operations before send operation

### DIFF
--- a/packages/ui-components/src/lib/types/fireBlocks.ts
+++ b/packages/ui-components/src/lib/types/fireBlocks.ts
@@ -53,6 +53,11 @@ export interface GetBootstrapTokenResponse {
   accessToken: string;
 }
 
+export interface GetOperationListResponse {
+  '@type': string;
+  items: Operation[];
+}
+
 export interface GetOperationResponse {
   '@type': string;
   operation: Operation;
@@ -88,6 +93,8 @@ export interface IDeviceStore {
 export interface Operation {
   '@type': string;
   id: string;
+  accountId: string;
+  assetId: string;
   lastUpdatedTimestamp: number;
   status: string;
   type: string;


### PR DESCRIPTION
Tie into the existing `useSubmitTransaction()` hook to clear the operation queue for an asset. This prevents the situation where a previous abandoned operation is awaiting signature, causing the send operation to hang indefinitely.