### PR TITLE
Explicit signature asset

### DIFF
--- a/packages/config/src/env/default.ts
+++ b/packages/config/src/env/default.ts
@@ -91,6 +91,7 @@ export default function getDefaultConfig(): Config {
         SEND: ['BTC/BTC', 'MATIC/MATIC', 'SOL/SOL', 'BASE/ETH', 'ETH/ETH'],
         DOMAINS: ['ETH', 'MATIC'],
       },
+      SIGNATURE_SYMBOL: 'POLYGON/MATIC',
     },
     PUSH: {
       CHANNELS: ['eip155:5:0x0389246fB9191Dc41722e1f0D558dC8f82Be3C7A'],

--- a/packages/config/src/env/types.ts
+++ b/packages/config/src/env/types.ts
@@ -100,6 +100,7 @@ export type Config = {
       SEND: string[];
       DOMAINS: string[];
     };
+    SIGNATURE_SYMBOL: string;
   };
   VERIFICATION_SUPPORTED: string[];
   PUSH: {

--- a/packages/ui-components/src/actions/fireBlocksActions.ts
+++ b/packages/ui-components/src/actions/fireBlocksActions.ts
@@ -374,7 +374,12 @@ export const getMessageSignature = async (
     // otherwise just retrieve the first first asset.
     const asset =
       assets.find(
-        a => a.address.toLowerCase() === opts?.address?.toLowerCase(),
+        a =>
+          a.blockchainAsset.blockchain.id.toLowerCase() ===
+            config.WALLETS.SIGNATURE_SYMBOL.split('/')[0].toLowerCase() &&
+          a.blockchainAsset.symbol.toLowerCase() ===
+            config.WALLETS.SIGNATURE_SYMBOL.split('/')[1].toLowerCase() &&
+          a.address.toLowerCase() === opts?.address?.toLowerCase(),
       ) || assets[0];
     if (!asset) {
       throw new Error('address not found in account');


### PR DESCRIPTION
Add a config property to choose the asset used by default for signatures. Default to MATIC on Polygon chain, since all wallets will have this asset.