### PR TITLE
Use ETH asset as default for signatures

### DIFF
--- a/packages/config/src/env/default.ts
+++ b/packages/config/src/env/default.ts
@@ -91,7 +91,7 @@ export default function getDefaultConfig(): Config {
         SEND: ['BTC/BTC', 'MATIC/MATIC', 'SOL/SOL', 'BASE/ETH', 'ETH/ETH'],
         DOMAINS: ['ETH', 'MATIC'],
       },
-      SIGNATURE_SYMBOL: 'POLYGON/MATIC',
+      SIGNATURE_SYMBOL: 'ETHEREUM/ETH',
     },
     PUSH: {
       CHANNELS: ['eip155:5:0x0389246fB9191Dc41722e1f0D558dC8f82Be3C7A'],

--- a/packages/ui-components/src/components/Wallet/DomainWalletTransactions.tsx
+++ b/packages/ui-components/src/components/Wallet/DomainWalletTransactions.tsx
@@ -77,6 +77,12 @@ const useStyles = makeStyles<StyleProps>()((theme: Theme, {palletteShade}) => ({
     borderRadius: theme.shape.borderRadius,
     border: `1px solid ${palletteShade[bgNeutralShade - 600]}`,
     padding: theme.spacing(2),
+    ['::-webkit-scrollbar']: {
+      display: 'none',
+    },
+  },
+  transactionContainer: {
+    border: '1px solid transparent',
   },
   infiniteScrollLoading: {
     width: '100%',
@@ -443,7 +449,11 @@ export const DomainWalletTransactions: React.FC<
               dataLength={(txns || []).length}
               scrollThreshold={0.7}
             >
-              <Grid container spacing={1}>
+              <Grid
+                container
+                spacing={1}
+                className={classes.transactionContainer}
+              >
                 {sortedTxns?.map((tx, i) =>
                   renderActivity(
                     i,

--- a/packages/ui-components/src/components/Wallet/TokensPortfolio.tsx
+++ b/packages/ui-components/src/components/Wallet/TokensPortfolio.tsx
@@ -35,6 +35,9 @@ const useStyles = makeStyles<StyleProps>()((theme: Theme, {palletteShade}) => ({
   walletListContainer: {
     display: 'flex',
     overflowX: 'auto',
+    ['::-webkit-scrollbar']: {
+      display: 'none',
+    },
   },
   walletContainer: {
     color: palletteShade[bgNeutralShade - 600],
@@ -110,7 +113,9 @@ const useStyles = makeStyles<StyleProps>()((theme: Theme, {palletteShade}) => ({
     borderRadius: theme.shape.borderRadius,
     border: `1px solid ${palletteShade[bgNeutralShade - 600]}`,
     padding: theme.spacing(2),
-    scrollbarWidth: 'thin',
+    ['::-webkit-scrollbar']: {
+      display: 'none',
+    },
   },
   noActivity: {
     color: palletteShade[bgNeutralShade - 600],
@@ -378,12 +383,12 @@ export const TokensPortfolio: React.FC<TokensPortfolioProps> = ({
           mt={'15px'}
           mb={2}
           id={`scrollablePortfolioDiv`}
-          className={classes.scrollableContainer}
+          className={cx(classes.scrollableContainer)}
         >
           <Grid container spacing={2}>
             <Grid item xs={12}>
               {wallets && (
-                <Box className={classes.walletListContainer}>
+                <Box className={cx(classes.walletListContainer)}>
                   {wallets.length > 1 && renderWallet()}
                   {wallets.map(wallet => renderWallet(wallet))}
                 </Box>


### PR DESCRIPTION
In order to align with the mobile wallet client, use the Ethereum/ETH asset as the default for generating message signatures. Previously Polygon/MATIC asset was used as the default. Using the same default will ensure the same signature result is created across the client implementations, which is important for the functionality of some apps such as XMTP and Push Protocol.