### PR TITLE
Improve UX for new empty wallet

### DIFF
--- a/packages/ui-components/src/components/Wallet/Client.tsx
+++ b/packages/ui-components/src/components/Wallet/Client.tsx
@@ -35,12 +35,6 @@ const useStyles = makeStyles()((theme: Theme) => ({
     width: '100%',
     height: `${MIN_CLIENT_HEIGHT}px`,
   },
-  loadingContainer: {
-    display: 'flex',
-    justifyContent: 'center',
-    height: `${MIN_CLIENT_HEIGHT - 125}px`,
-    alignItems: 'center',
-  },
   walletContainer: {
     display: 'flex',
     flexDirection: 'column',
@@ -323,6 +317,9 @@ export const Client: React.FC<ClientProps> = ({
                   value={ClientTabType.Transactions}
                   label={t('activity.title')}
                   iconPosition="start"
+                  disabled={
+                    !wallets?.some(w => w.txns?.data && w.txns.data.length > 0)
+                  }
                 />
               </TabList>
             </Box>

--- a/packages/ui-components/src/components/Wallet/Configuration.tsx
+++ b/packages/ui-components/src/components/Wallet/Configuration.tsx
@@ -199,9 +199,6 @@ export const Configuration: React.FC<
   }, [configState, accessToken]);
 
   useEffect(() => {
-    if (onLoaded) {
-      onLoaded(isLoaded);
-    }
     if (!isLoaded) {
       return;
     }
@@ -377,6 +374,11 @@ export const Configuration: React.FC<
     // display rendered wallets
     setMpcWallets(wallets.sort((a, b) => a.name.localeCompare(b.name)));
     setIsLoaded(true);
+
+    // set loaded flag if provided
+    if (onLoaded) {
+      onLoaded(true);
+    }
 
     // clear fetching flag if provided
     if (setIsFetching) {
@@ -738,7 +740,10 @@ export const Configuration: React.FC<
 
   return (
     <Box className={classes.container}>
-      {isLoaded ? (
+      {isLoaded &&
+      (configState !== WalletConfigState.Complete ||
+        mode === 'basic' ||
+        mpcWallets.length > 0) ? (
         isSaving || errorMessage ? (
           <Box mt={5} textAlign="center">
             <OperationStatus

--- a/packages/ui-components/src/components/Wallet/Token.tsx
+++ b/packages/ui-components/src/components/Wallet/Token.tsx
@@ -96,6 +96,7 @@ export type TokenEntry = {
   walletAddress: string;
   walletBlockChainLink: string;
   walletName: string;
+  walletType?: string;
 };
 
 type Props = {

--- a/packages/ui-components/src/components/Wallet/TokensPortfolio.tsx
+++ b/packages/ui-components/src/components/Wallet/TokensPortfolio.tsx
@@ -175,6 +175,7 @@ export const TokensPortfolio: React.FC<TokensPortfolioProps> = ({
           walletAddress: wallet.address,
           walletBlockChainLink: wallet.blockchainScanUrl,
           walletName: wallet.name,
+          walletType: wallet.walletType,
           imageUrl: wallet.logoUrl,
         };
       }),
@@ -221,6 +222,7 @@ export const TokensPortfolio: React.FC<TokensPortfolioProps> = ({
             walletAddress: wallet.address,
             walletBlockChainLink: wallet.blockchainScanUrl,
             walletName: wallet.name,
+            walletType: wallet.walletType,
             imageUrl: walletNft.collectionImageUrl,
           };
         }),
@@ -244,12 +246,13 @@ export const TokensPortfolio: React.FC<TokensPortfolioProps> = ({
             walletAddress: wallet.address,
             walletBlockChainLink: wallet.blockchainScanUrl,
             walletName: wallet.name,
+            walletType: wallet.walletType,
             imageUrl: walletToken.logoUrl,
           };
         }),
       ),
     ]
-      .filter(item => item?.value > 0.01)
+      .filter(item => item?.value > 0.01 || item?.walletType === 'mpc')
       .sort((a, b) => b.value - a.value)
       .filter(
         item =>

--- a/packages/ui-components/src/lib/types/domain.ts
+++ b/packages/ui-components/src/lib/types/domain.ts
@@ -455,6 +455,7 @@ export type SerializedWalletBalance = SerializedWalletToken & {
   blockchainScanUrl: string;
   totalValueUsd?: string;
   totalValueUsdAmt?: number;
+  walletType?: string;
 };
 
 export type SerializedWalletNftCollection = {


### PR DESCRIPTION
A new (empty) wallet should be populated with interesting placeholder data, and the "activity" tab should be disabled.

## Screenshot
<img width="643" alt="image" src="https://github.com/unstoppabledomains/domain-profiles/assets/21039114/e17210a7-663a-4351-8a7a-91a2d2e82d17">
