### PR TITLE
Use more generic validation to determine resolver status

### DIFF
--- a/packages/ui-components/src/components/Wallet/AddressInput.tsx
+++ b/packages/ui-components/src/components/Wallet/AddressInput.tsx
@@ -9,7 +9,7 @@ import {makeStyles} from '@unstoppabledomains/ui-kit/styles';
 
 import {getProfileData} from '../../actions';
 import useResolverKeys from '../../hooks/useResolverKeys';
-import {DomainFieldTypes, isValidDomain} from '../../lib';
+import {DomainFieldTypes, isDomainValidForManagement} from '../../lib';
 import type {ResolverKeyName} from '../../lib/types/resolverKeys';
 import {getAddressMetadata} from '../Chat/protocol/resolution';
 import ManageInput from '../Manage/common/ManageInput';
@@ -141,7 +141,7 @@ const AddressInput: React.FC<Props> = ({
     }
 
     // forward resolve domain to address
-    if (isValidDomain(addressOrDomain)) {
+    if (isDomainValidForManagement(addressOrDomain)) {
       timeout.current = setTimeout(async () => {
         setIsLoading(true);
         const resolvedAddress =

--- a/packages/ui-components/src/lib/types/domain.ts
+++ b/packages/ui-components/src/lib/types/domain.ts
@@ -555,11 +555,6 @@ export type YoutubeUserInfo = {
   subscriberCount: number;
 } | null;
 
-export const isValidDomain = (domain: string): boolean => {
-  const domainSuffix = domain.split('.').pop();
-  return Object.values(DomainSuffixes).includes(domainSuffix as DomainSuffixes);
-};
-
 export const kbToMb = (kb: number): number => {
   return kb / 1000 / 1024;
 };


### PR DESCRIPTION
The validation logic used to determine if a name should be resolved is too restrictive. Remove the undesirable validator and use an existing validator that has preferable logic.