### PR TITLE
[REG-1302] Hide showing null addresses

### DIFF
--- a/packages/ui-components/src/lib/domain/records.ts
+++ b/packages/ui-components/src/lib/domain/records.ts
@@ -2,6 +2,8 @@ import mapKeys from 'lodash/mapKeys';
 import pickBy from 'lodash/pickBy';
 import reduce from 'lodash/reduce';
 
+import {NullAddress} from '@unstoppabledomains/resolution/build/types';
+
 import type {
   MulticoinAddresses,
   MulticoinVersions,
@@ -40,6 +42,12 @@ export const parseRecords = (
     (_v, k) => k.split('.')[1],
   );
 
+  // Remove null and empty addresses
+  for (const key in addresses) {
+    if (addresses[key] === '0x' || addresses[key] === NullAddress) {
+      delete addresses[key];
+    }
+  }
   return {
     addresses,
     multicoinAddresses: mapMultiCoinAddresses(records),


### PR DESCRIPTION
[Linear](https://linear.app/unstoppable-domains/issue/REG-1302/bug-when-removing-solana-from-eth)

Bug for .eth domains managed on ens.domains

When removing addresses for .eth domains on ENS website, they set the address to a null address 0x00000... or 0x. We end up showing this null address in the profile page when we should hide it

<img width="384" alt="Screenshot 2024-07-05 at 12 12 45 PM" src="https://github.com/unstoppabledomains/domain-profiles/assets/23408540/7b0ab1d8-bbcc-4e81-8edf-50907c8d8328">
<img width="722" alt="Screenshot 2024-07-05 at 12 13 15 PM" src="https://github.com/unstoppabledomains/domain-profiles/assets/23408540/0b382df3-6367-4771-b4d4-70adcd92a310">
