### PR TITLE
Explicitly request hex encoding when signing messages with Lite Wallet

### DIFF
--- a/packages/ui-components/src/actions/fireBlocksActions.ts
+++ b/packages/ui-components/src/actions/fireBlocksActions.ts
@@ -403,7 +403,10 @@ export const getMessageSignature = async (
           Authorization: `Bearer ${accessToken}`,
         },
         host: config.WALLETS.HOST_URL,
-        body: JSON.stringify({message, encoding: 'utf8'}),
+        body: JSON.stringify({
+          message,
+          encoding: message.startsWith('0x') ? 'hex' : 'utf8',
+        }),
       },
     );
     if (!operationResponse) {

--- a/packages/ui-components/src/actions/fireBlocksActions.ts
+++ b/packages/ui-components/src/actions/fireBlocksActions.ts
@@ -1,4 +1,5 @@
 import Bluebird from 'bluebird';
+import {utils as EthersUtils} from 'ethers';
 import QueryString from 'qs';
 
 import config from '@unstoppabledomains/config';
@@ -405,7 +406,7 @@ export const getMessageSignature = async (
         host: config.WALLETS.HOST_URL,
         body: JSON.stringify({
           message,
-          encoding: message.startsWith('0x') ? 'hex' : 'utf8',
+          encoding: EthersUtils.isHexString(message) ? 'hex' : 'utf8',
         }),
       },
     );


### PR DESCRIPTION
When using Lite Wallet to sign a hex message such as `0x23eca67464edb5f5b81248918309675990af00436b1da7b47d625ec24c0e8be2`, the `hex` encoding parameter must be passed along with the signing request. Historically, this encoding was determined automatically on the server side but is no longer the case. 