### PR TITLE
Revert to signed out state when tokens are invalid

### DIFF
--- a/packages/ui-components/src/components/Wallet/Configuration.tsx
+++ b/packages/ui-components/src/components/Wallet/Configuration.tsx
@@ -439,7 +439,7 @@ export const Configuration: React.FC<
 
       // unable to retrieve access token, so revert back to configuration
       // state before returning
-      setConfigState(WalletConfigState.PasswordEntry);
+      handleLogout();
     } finally {
       setIsLoaded(true);
     }


### PR DESCRIPTION
If a user's access tokens for Unstoppable Lite wallet have become invalid, prompt the user to sign in again.