### PR TITLE
Prompt for Lite Wallet login when token refresh fails

### DIFF
--- a/packages/ui-components/src/components/Header/AccountButton.tsx
+++ b/packages/ui-components/src/components/Header/AccountButton.tsx
@@ -91,12 +91,14 @@ export const AccountButton: React.FC<AccountButtonProps> = ({
   domain,
   authAddress,
   authDomain,
+  setAuthAddress,
 }) => {
   const {classes, cx} = useStyles();
   const [isOwner, setIsOwner] = useState(false);
   const [isDropDownShown, setDropDownShown] = useState(false);
   const [authDomainAvatar, setAuthDomainAvatar] = useState<string>('');
   const [isMpcWalletOpen, setIsMpcWalletOpen] = useState(false);
+  const [buttonComponent, setButtonComponent] = useState<React.ReactNode>();
   const [domainProfileData, setDomainProfileData] =
     useState<SerializedPublicDomainProfileData>();
 
@@ -198,10 +200,14 @@ export const AccountButton: React.FC<AccountButtonProps> = ({
               onUpdate={(_t: DomainProfileTabType) => {
                 return;
               }}
-              setButtonComponent={(_v: React.ReactFragment) => {
-                return;
-              }}
+              setButtonComponent={setButtonComponent}
+              setAuthAddress={setAuthAddress}
             />
+            {!authAddress && (
+              <Box display="flex" flexDirection="column" width="100%" mt={2}>
+                {buttonComponent}
+              </Box>
+            )}
           </Box>
         </Modal>
       )}
@@ -214,4 +220,5 @@ export type AccountButtonProps = {
   domain: string;
   authAddress: string;
   authDomain: string;
+  setAuthAddress?: (v: string) => void;
 };

--- a/packages/ui-components/src/components/Wallet/Configuration.tsx
+++ b/packages/ui-components/src/components/Wallet/Configuration.tsx
@@ -49,6 +49,7 @@ import {
   saveBootstrapState,
 } from '../../lib/fireBlocks/storage/state';
 import type {SerializedIdentityResponse} from '../../lib/types/identity';
+import {isEthAddress} from '../Chat/protocol/resolution';
 import {DomainProfileTabType} from '../Manage/DomainProfile';
 import ManageInput from '../Manage/common/ManageInput';
 import type {ManageTabProps} from '../Manage/common/types';
@@ -135,12 +136,14 @@ export const Configuration: React.FC<
     setIsFetching?: (v?: boolean) => void;
     isHeaderClicked: boolean;
     setIsHeaderClicked?: (v: boolean) => void;
+    setAuthAddress?: (v: string) => void;
   }
 > = ({
   onUpdate,
   onLoaded,
   setButtonComponent,
   setIsFetching,
+  setAuthAddress,
   isHeaderClicked,
   setIsHeaderClicked,
   mode = 'basic',
@@ -369,6 +372,14 @@ export const Configuration: React.FC<
       }),
     ]);
 
+    // set authenticated address if applicable
+    if (setAuthAddress && isLoaded) {
+      const accountAddress = accountAddresses.find(v => isEthAddress(v));
+      if (accountAddress) {
+        setAuthAddress(accountAddress);
+      }
+    }
+
     // set payment config status
     setPaymentConfigStatus(paymentConfig);
 
@@ -474,6 +485,11 @@ export const Configuration: React.FC<
     setEmailAddress(undefined);
     setRecoveryPhrase(undefined);
     setRecoveryPhraseConfirmation(undefined);
+
+    // clear authenticated address if necessary
+    if (setAuthAddress) {
+      setAuthAddress('');
+    }
 
     // clear all storage state
     saveState({});

--- a/packages/ui-components/src/components/Wallet/Wallet.tsx
+++ b/packages/ui-components/src/components/Wallet/Wallet.tsx
@@ -24,6 +24,7 @@ export const Wallet: React.FC<
     recoveryToken?: string;
     showMessages?: boolean;
     mode?: WalletMode;
+    setAuthAddress?: (v: string) => void;
   }
 > = ({
   emailAddress,
@@ -34,6 +35,7 @@ export const Wallet: React.FC<
   showMessages,
   mode = 'basic',
   onUpdate,
+  setAuthAddress,
   setButtonComponent,
 }) => {
   const {classes} = useStyles();
@@ -80,6 +82,7 @@ export const Wallet: React.FC<
         setIsFetching={setIsFetching}
         isHeaderClicked={isHeaderClicked}
         setIsHeaderClicked={setIsHeaderClicked}
+        setAuthAddress={setAuthAddress}
       />
     </Box>
   );

--- a/server/pages/[domain]/index.page.tsx
+++ b/server/pages/[domain]/index.page.tsx
@@ -667,6 +667,7 @@ const DomainProfile = ({
                       domainOwner={ownerAddress}
                       authAddress={authAddress}
                       authDomain={authDomain}
+                      setAuthAddress={setAuthAddress}
                     />
                   </>
                 ) : (

--- a/server/pages/badge/[badgeCode].page.tsx
+++ b/server/pages/badge/[badgeCode].page.tsx
@@ -190,6 +190,7 @@ const BadgePage = ({
                     domainOwner={''}
                     authAddress={authAddress}
                     authDomain={authDomain}
+                    setAuthAddress={setAuthAddress}
                   />
                 </>
               ) : (

--- a/server/pages/wallet/index.page.tsx
+++ b/server/pages/wallet/index.page.tsx
@@ -211,6 +211,7 @@ const WalletPage = () => {
                   onUpdate={(_t: DomainProfileTabType) => {
                     handleAuthComplete();
                   }}
+                  setAuthAddress={setAuthAddress}
                   setButtonComponent={setAuthButton}
                 />
                 {!authAddress && (


### PR DESCRIPTION
There is an edge case where a stale refresh token results in an error retrieving a fresh access token. Currently, this results in displaying a login panel, but with no button to "continue" signing in. This PR resolves this state management so the button is displayed as expected.