### PR TITLE
Disable ENS xfer for unwrapped domains

### DIFF
--- a/packages/ui-components/src/actions/fireBlocksActions.ts
+++ b/packages/ui-components/src/actions/fireBlocksActions.ts
@@ -725,8 +725,11 @@ export const signAndWait = async (
         throw new Error(`signature ${operationStatus.status.toLowerCase()}`);
       }
 
-      // return the completed signature
-      if (operationStatus.status === 'COMPLETED') {
+      // return the completed signature or a transaction ID is available
+      if (
+        operationStatus.status === 'COMPLETED' ||
+        operationStatus.transaction?.id?.startsWith('0x')
+      ) {
         if (opts?.onStatusChange) {
           opts.onStatusChange('signature completed');
         }

--- a/packages/ui-components/src/locales/en.json
+++ b/packages/ui-components/src/locales/en.json
@@ -395,6 +395,7 @@
     "transferConfirmation3": "I'm transferring to a wallet address on the {{chainName}} network",
     "transferConfirmation4": "Clear records upon transfer (Optional)",
     "transferDescription": "Your domain can be transferred to another wallet. Make sure to read each item in the checklist carefully to ensure your domain is transferred safely.",
+    "transferDisabledForErc721": "Coming soon for unwrapped ENS domains",
     "transferRequestError": "Error requesting domain transfer",
     "transferWarning": "You must have the private key in order to manage your domain. If you transfer this domain to an exchange or any other custodial account where you do not control the private key, you will not be able to access your domain. Not your keys, not your domain.",
     "unblock": "Unblock",


### PR DESCRIPTION
Until the backend supports the 2-stage transfer for wrapped (ERC721) ENS domains, disable support on the UI.