### PR TITLE
Introduce XMTP conversation allowlist

### DIFF
--- a/packages/config/src/env/default.ts
+++ b/packages/config/src/env/default.ts
@@ -128,6 +128,10 @@ export default function getDefaultConfig(): Config {
       SUPPORT_WALLET_ADDRESS: '0xf7Ef453121bF016e4441F0c06e0951223fdbbB01',
       SUPPORT_DOMAIN_NAME: 'support.crypto',
       SUPPORT_BUBBLE_SECONDS: 60,
+      CONVERSATION_ALLOW_LIST: [
+        '0xf7Ef453121bF016e4441F0c06e0951223fdbbB01',
+        '0xB6EB29d3C39a4bDC54F0E46dDa5903B7a5019Dd1',
+      ],
     },
     GATEWAY_API_KEY: process.env.GATEWAY_API_KEY || '',
   };

--- a/packages/config/src/env/production.ts
+++ b/packages/config/src/env/production.ts
@@ -63,6 +63,10 @@ export default function getProductionConfig(): ConfigOverride {
       ENVIRONMENT: 'production',
       SUPPORT_WALLET_ADDRESS: '0x9B4Ed628640A73154895e369AE39a93732535924',
       SUPPORT_DOMAIN_NAME: 'support.unstoppable.x',
+      CONVERSATION_ALLOW_LIST: [
+        '0x9B4Ed628640A73154895e369AE39a93732535924',
+        '0x66cB02a8C85De1cdEABF8D88B4045F59720b8Ede',
+      ],
     },
   };
 }

--- a/packages/config/src/env/types.ts
+++ b/packages/config/src/env/types.ts
@@ -123,6 +123,7 @@ export type Config = {
     SUPPORT_WALLET_ADDRESS: string;
     SUPPORT_DOMAIN_NAME: string;
     SUPPORT_BUBBLE_SECONDS: number;
+    CONVERSATION_ALLOW_LIST: string[];
   };
   GATEWAY_API_KEY: string;
 };

--- a/packages/ui-components/src/components/Chat/modal/ChatModal.tsx
+++ b/packages/ui-components/src/components/Chat/modal/ChatModal.tsx
@@ -50,7 +50,11 @@ import Modal from '../../Modal';
 import {registerClientTopics} from '../protocol/registration';
 import {getAddressMetadata} from '../protocol/resolution';
 import type {ConversationMeta} from '../protocol/xmtp';
-import {getConversation, getConversations} from '../protocol/xmtp';
+import {
+  getConversation,
+  getConversations,
+  isAllowListed,
+} from '../protocol/xmtp';
 import type {AddressResolution, PayloadData} from '../types';
 import {TabType, getCaip10Address} from '../types';
 import CallToAction from './CallToAction';
@@ -315,12 +319,20 @@ export const ChatModal: React.FC<ChatModalProps> = ({
     if (acceptedTopics.length === 0 && blockedTopics.length === 0) {
       setAcceptedTopics(
         conversations
-          .filter(c => c.consentState === 'allowed')
+          .filter(
+            c =>
+              c.consentState === 'allowed' ||
+              isAllowListed(c.conversation.peerAddress),
+          )
           .map(c => c.conversation.topic),
       );
       setBlockedTopics(
         conversations
-          .filter(c => c.consentState === 'denied')
+          .filter(
+            c =>
+              c.consentState === 'denied' &&
+              !isAllowListed(c.conversation.peerAddress),
+          )
           .map(c => c.conversation.topic),
       );
     }

--- a/packages/ui-components/src/components/Chat/modal/dm/Conversation.tsx
+++ b/packages/ui-components/src/components/Chat/modal/dm/Conversation.tsx
@@ -37,7 +37,7 @@ import useTranslationContext from '../../../../lib/i18n';
 import type {Web3Dependencies} from '../../../../lib/types/web3';
 import {registerClientTopics} from '../../protocol/registration';
 import {getAddressMetadata} from '../../protocol/resolution';
-import {waitForXmtpMessages} from '../../protocol/xmtp';
+import {isAllowListed, waitForXmtpMessages} from '../../protocol/xmtp';
 import type {AddressResolution} from '../../types';
 import CallToAction from '../CallToAction';
 import {useConversationStyles} from '../styles';
@@ -331,23 +331,26 @@ export const Conversation: React.FC<ConversationProps> = ({
               transformOrigin={{horizontal: 'right', vertical: 'top'}}
               anchorOrigin={{horizontal: 'right', vertical: 'bottom'}}
             >
-              {authDomain && isDomainValidForManagement(authDomain) && (
-                <MenuItem
-                  onClick={() => {
-                    handleCloseMenu();
-                    void handleBlockClicked(!isBlocked());
-                  }}
-                >
-                  <ListItemIcon>
-                    <BlockOutlinedIcon fontSize="small" />
-                  </ListItemIcon>
-                  <Typography variant="body2">
-                    {isBlocked()
-                      ? t('manage.unblock')
-                      : t('push.blockAndReport')}
-                  </Typography>
-                </MenuItem>
-              )}
+              {authDomain &&
+                peerAddress &&
+                isDomainValidForManagement(authDomain) &&
+                !isAllowListed(peerAddress) && (
+                  <MenuItem
+                    onClick={() => {
+                      handleCloseMenu();
+                      void handleBlockClicked(!isBlocked());
+                    }}
+                  >
+                    <ListItemIcon>
+                      <BlockOutlinedIcon fontSize="small" />
+                    </ListItemIcon>
+                    <Typography variant="body2">
+                      {isBlocked()
+                        ? t('manage.unblock')
+                        : t('push.blockAndReport')}
+                    </Typography>
+                  </MenuItem>
+                )}
               <MenuItem
                 onClick={() => {
                   handleCloseMenu();

--- a/packages/ui-components/src/components/Chat/protocol/xmtp.ts
+++ b/packages/ui-components/src/components/Chat/protocol/xmtp.ts
@@ -217,6 +217,12 @@ export const isXmtpUser = async (address: string): Promise<boolean> => {
   return await Client.canMessage(address, xmtpOpts);
 };
 
+export const isAllowListed = (address: string) => {
+  return config.XMTP.CONVERSATION_ALLOW_LIST.map(a => a.toLowerCase()).includes(
+    address.toLowerCase(),
+  );
+};
+
 // loadConversationConsentState retrieves the consent state for this conversation
 export const loadConversationConsentState = async (
   xmtp: Client,


### PR DESCRIPTION
A configurable list of wallet addresses to show by default in the XMTP chat client. By default, the following users are shown in the chat:

- Unstoppable support team
- Unstoppable Lite Wallet notifications