### PR TITLE
Allow configuration timeout on fetch wrapper

### DIFF
--- a/packages/ui-components/src/lib/fetchApi.ts
+++ b/packages/ui-components/src/lib/fetchApi.ts
@@ -43,17 +43,18 @@ export const fetchApi = async <T = any>(
 
   // prepare the abort controller to send a signal to fetch when the
   // request timeout has been exceeded
+  const requestTimeout = options.timeout || DEFAULT_TIMEOUT_MS;
   const cancelController = new AbortController();
   options.signal = cancelController.signal;
 
   // set a timer to fire at the requested timeout
   const cancelTimer = setTimeout(() => {
-    const cancelMsg = `request timeout after ${options.timeout}ms`;
+    const cancelMsg = `request timeout after ${requestTimeout}ms`;
     notifyEvent(new Error(cancelMsg), 'error', 'Request', 'Fetch', {
       meta: {url},
     });
     cancelController.abort(cancelMsg);
-  }, options.timeout || DEFAULT_TIMEOUT_MS);
+  }, requestTimeout);
 
   // make the request
   return fetch(url, options)


### PR DESCRIPTION
All client requests use a `fetchApi()` wrapper for outbound API calls. However, the wrapper does not currently use an explicit timeout. This means that the browser defaults control the request timeouts, and this can vary from browser to browser. Some examples:

- Chrome: 5 minutes
- Firefox: 90 seconds
- Safari: 60 seconds

This PR introduces an explicit default timeout of 5 minutes, and also allows an optional `timeout` parameter to be passed in order to override the timeout for specific requests.