### PR TITLE
Check for clock drift during Lite Wallet sign in

### DIFF
--- a/packages/config/src/env/default.ts
+++ b/packages/config/src/env/default.ts
@@ -116,7 +116,7 @@ export default function getDefaultConfig(): Config {
           'https://apps.apple.com/us/app/unstoppable-domains/id1544748602',
       },
       SIGNATURE_SYMBOL: 'ETHEREUM/ETH',
-      MAX_CLOCK_DRIFT_MS: 2500, // 2.5 seconds
+      MAX_CLOCK_DRIFT_MS: 2000, // 2 seconds
     },
     PUSH: {
       CHANNELS: ['eip155:5:0x0389246fB9191Dc41722e1f0D558dC8f82Be3C7A'],

--- a/packages/config/src/env/default.ts
+++ b/packages/config/src/env/default.ts
@@ -116,7 +116,7 @@ export default function getDefaultConfig(): Config {
           'https://apps.apple.com/us/app/unstoppable-domains/id1544748602',
       },
       SIGNATURE_SYMBOL: 'ETHEREUM/ETH',
-      MAX_CLOCK_DRIFT_MS: 1500, // 1.5 seconds
+      MAX_CLOCK_DRIFT_MS: 2500, // 2.5 seconds
     },
     PUSH: {
       CHANNELS: ['eip155:5:0x0389246fB9191Dc41722e1f0D558dC8f82Be3C7A'],

--- a/packages/config/src/env/default.ts
+++ b/packages/config/src/env/default.ts
@@ -116,6 +116,7 @@ export default function getDefaultConfig(): Config {
           'https://apps.apple.com/us/app/unstoppable-domains/id1544748602',
       },
       SIGNATURE_SYMBOL: 'ETHEREUM/ETH',
+      MAX_CLOCK_DRIFT_MS: 1500, // 1.5 seconds
     },
     PUSH: {
       CHANNELS: ['eip155:5:0x0389246fB9191Dc41722e1f0D558dC8f82Be3C7A'],

--- a/packages/config/src/env/types.ts
+++ b/packages/config/src/env/types.ts
@@ -110,6 +110,7 @@ export type Config = {
       ANDROID_URL: string;
       APPLE_URL: string;
     };
+    MAX_CLOCK_DRIFT_MS: number;
   };
   VERIFICATION_SUPPORTED: string[];
   PUSH: {

--- a/packages/ui-components/src/actions/walletActions.ts
+++ b/packages/ui-components/src/actions/walletActions.ts
@@ -48,7 +48,7 @@ export const createWalletOtp = async (
 
 export const getOnboardingStatus = async (
   emailAddress: string,
-): Promise<boolean> => {
+): Promise<WalletAccountResponse | undefined> => {
   try {
     const accountStatus = await fetchApi<WalletAccountResponse>(
       `/user/${encodeURIComponent(emailAddress)}/wallet/account`,
@@ -58,12 +58,12 @@ export const getOnboardingStatus = async (
       },
     );
     if (accountStatus?.active) {
-      return true;
+      return accountStatus;
     }
   } catch (e) {
     notifyEvent(e, 'warning', 'Wallet', 'Validation');
   }
-  return false;
+  return undefined;
 };
 
 export const getWalletPortfolio = async (

--- a/packages/ui-components/src/components/Chat/protocol/xmtp.ts
+++ b/packages/ui-components/src/components/Chat/protocol/xmtp.ts
@@ -213,14 +213,14 @@ export const initXmtpAccount = async (address: string, signer: Signer) => {
   }
 };
 
-export const isXmtpUser = async (address: string): Promise<boolean> => {
-  return await Client.canMessage(address, xmtpOpts);
-};
-
 export const isAllowListed = (address: string) => {
   return config.XMTP.CONVERSATION_ALLOW_LIST.map(a => a.toLowerCase()).includes(
     address.toLowerCase(),
   );
+};
+
+export const isXmtpUser = async (address: string): Promise<boolean> => {
+  return await Client.canMessage(address, xmtpOpts);
 };
 
 // loadConversationConsentState retrieves the consent state for this conversation

--- a/packages/ui-components/src/components/Manage/Tabs/Transfer.tsx
+++ b/packages/ui-components/src/components/Manage/Tabs/Transfer.tsx
@@ -14,7 +14,6 @@ import {useDebounce} from 'usehooks-ts';
 
 import {makeStyles} from '@unstoppabledomains/ui-kit/styles';
 
-import {getProfileData} from '../../../actions';
 import {
   confirmRecordUpdate,
   getRegistrationMessage,
@@ -24,7 +23,6 @@ import {
 import {useWeb3Context} from '../../../hooks';
 import type {CreateTransaction} from '../../../lib';
 import {
-  DomainFieldTypes,
   isExternalDomain,
   useTranslationContext,
 } from '../../../lib';

--- a/packages/ui-components/src/components/Wallet/Configuration.tsx
+++ b/packages/ui-components/src/components/Wallet/Configuration.tsx
@@ -48,6 +48,7 @@ import {notifyEvent} from '../../lib/error';
 import {
   getFireBlocksClient,
   initializeClient,
+  isClockDrift,
   signTransaction,
 } from '../../lib/fireBlocks/client';
 import {
@@ -703,9 +704,20 @@ export const Configuration: React.FC<
     }
 
     // check for onboarding
-    const isOnboarded = await getOnboardingStatus(emailAddress);
-    if (!isOnboarded) {
+    const onboardStatus = await getOnboardingStatus(emailAddress);
+    if (!onboardStatus) {
       setConfigState(WalletConfigState.NeedsOnboarding);
+      return;
+    }
+
+    // check system clock synchronization
+    if (isClockDrift(onboardStatus.clock)) {
+      setErrorMessage(
+        t('wallet.clockDriftError', {
+          deviceTime: new Date().toLocaleString(),
+          expectedTime: new Date(onboardStatus.clock).toLocaleString(),
+        }),
+      );
       return;
     }
 

--- a/packages/ui-components/src/lib/fireBlocks/client.ts
+++ b/packages/ui-components/src/lib/fireBlocks/client.ts
@@ -6,6 +6,8 @@ import type {
 } from '@fireblocks/ncw-js-sdk';
 import {FireblocksNCWFactory} from '@fireblocks/ncw-js-sdk';
 
+import config from '@unstoppabledomains/config';
+
 import {
   sendJoinRequest,
   sendResetRequest,
@@ -144,6 +146,17 @@ export const initializeClient = async (
   }
 
   // the request to join was not successful
+  return false;
+};
+
+export const isClockDrift = (oracleMs: number): boolean => {
+  const clockDriftMs = Math.abs(new Date().getTime() - oracleMs);
+  if (clockDriftMs > config.WALLETS.MAX_CLOCK_DRIFT_MS) {
+    notifyEvent('detected clock drift', 'error', 'Wallet', 'Validation', {
+      meta: {oracleMs, clockDriftMs},
+    });
+    return true;
+  }
   return false;
 };
 

--- a/packages/ui-components/src/lib/types/wallet.ts
+++ b/packages/ui-components/src/lib/types/wallet.ts
@@ -18,6 +18,7 @@ export type WagmiConnectorType =
 export interface WalletAccountResponse {
   emailAddress: string;
   active: boolean;
+  clock: number;
   records?: Record<string, string>;
 }
 

--- a/packages/ui-components/src/locales/en.json
+++ b/packages/ui-components/src/locales/en.json
@@ -855,6 +855,7 @@
     "beginSetup": "Continue",
     "bootstrapCode": "One-time code",
     "bootstrapCodeDescription": "## Confirm login\nThe one-time code sent to **{{emailAddress}}** is required to access Unstoppable Lite Wallet on this device.",
+    "clockDriftError": "Device clock ({{deviceTime}}) is out of sync with wallet provider ({{expectedTime}}). Update your settings and try again.",
     "completeSetup": "Continue",
     "configuringWallet": "Configuring wallet...",
     "confirmRecoveryPhrase": "Confirm",


### PR DESCRIPTION
The device's local time plays a role in Fireblocks certificate validation and signing operations. If the local clock is out of sync by even 2 seconds, errors will occur during sign in. This PR adds a clock drift check against a time oracle provided by the Unstoppable Domains backend service. If the clock is out of sync:

- A helpful error message is show to the user
- The error is logged so that UD can have visibility to how often this scenario occurs

## Screenshot
Example error message when clock is out of sync.

<img width="1149" alt="image" src="https://github.com/user-attachments/assets/51fc6ad2-fbb2-4168-8c33-a1a85e736b45">