### PR TITLE
Add retry logic for Fireblocks signing operations

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -108,6 +108,7 @@
     "title-case": "^3.0.3",
     "truncate-eth-address": "^1.0.2",
     "truncate-middle": "^1.0.6",
+    "ts-retry": "^5.0.1",
     "tss-react": "^4.0.0",
     "typescript": "5.0.4",
     "uns": "https://github.com/unstoppabledomains/uns#v0.8.35",

--- a/packages/ui-components/src/hooks/useFireblocksTxSigner.ts
+++ b/packages/ui-components/src/hooks/useFireblocksTxSigner.ts
@@ -1,3 +1,5 @@
+import {retryAsync} from 'ts-retry';
+
 import {
   createTransactionOperation,
   signAndWait,
@@ -5,7 +7,7 @@ import {
 import {notifyEvent} from '../lib/error';
 import {getFireBlocksClient} from '../lib/fireBlocks/client';
 import {getBootstrapState} from '../lib/fireBlocks/storage/state';
-import type {GetOperationStatusResponse} from '../lib/types/fireBlocks';
+import {GetOperationStatusResponse, MAX_RETRIES} from '../lib/types/fireBlocks';
 import useFireblocksAccessToken from './useFireblocksAccessToken';
 import useFireblocksState from './useFireblocksState';
 
@@ -20,8 +22,8 @@ const useFireblocksTxSigner = (): FireblocksTxSigner => {
   const [state, saveState] = useFireblocksState();
   const getAccessToken = useFireblocksAccessToken();
 
-  // return the fireblocks client signer
-  return async (
+  // define the fireblocks client signer
+  const signingFn = async (
     chainId: number,
     contractAddress: string,
     data: string,
@@ -99,6 +101,11 @@ const useFireblocksTxSigner = (): FireblocksTxSigner => {
       },
     );
 
+    // validate and return the signature result
+    if (!txOp?.transaction?.id) {
+      throw new Error('signature failed');
+    }
+
     // indicate complete with successful signature result
     notifyEvent('signature successful', 'info', 'Wallet', 'Signature', {
       meta: {
@@ -109,12 +116,31 @@ const useFireblocksTxSigner = (): FireblocksTxSigner => {
         txOp,
       },
     });
-
-    // validate and return the signature result
-    if (!txOp?.transaction?.id) {
-      throw new Error('signature failed');
-    }
     return txOp.transaction.id;
+  };
+
+  // wrap the signing function in retry logic to ensure it has a chance to
+  // succeed if there are intermittent failures
+  return async (
+    chainId: number,
+    contractAddress: string,
+    data: string,
+    value?: string,
+  ): Promise<string> => {
+    // wrap the signing function in retry logic
+    return retryAsync(
+      async () => await signingFn(chainId, contractAddress, data, value),
+      {
+        delay: 100,
+        maxTry: MAX_RETRIES,
+        onError: (err: Error, currentTry: number) => {
+          notifyEvent(err, 'warning', 'Wallet', 'Signature', {
+            msg: 'encountered transaction error in retry logic',
+            meta: {currentTry},
+          });
+        },
+      },
+    );
   };
 };
 

--- a/packages/ui-components/src/hooks/useFireblocksTxSigner.ts
+++ b/packages/ui-components/src/hooks/useFireblocksTxSigner.ts
@@ -7,7 +7,8 @@ import {
 import {notifyEvent} from '../lib/error';
 import {getFireBlocksClient} from '../lib/fireBlocks/client';
 import {getBootstrapState} from '../lib/fireBlocks/storage/state';
-import {GetOperationStatusResponse, MAX_RETRIES} from '../lib/types/fireBlocks';
+import type {GetOperationStatusResponse} from '../lib/types/fireBlocks';
+import { MAX_RETRIES} from '../lib/types/fireBlocks';
 import useFireblocksAccessToken from './useFireblocksAccessToken';
 import useFireblocksState from './useFireblocksState';
 

--- a/packages/ui-components/src/lib/types/fireBlocks.ts
+++ b/packages/ui-components/src/lib/types/fireBlocks.ts
@@ -1,5 +1,3 @@
-export const MAX_RETRIES = 5;
-
 export interface Account {
   '@type': string;
   id: string;
@@ -50,9 +48,9 @@ export interface CreateTransaction {
   data: string;
   value?: string;
 }
+
 export const EIP_712_KEY = 'EIP712Domain';
 export const FireblocksStateKey = 'fireblocks-state';
-
 export interface GetAccountAssetsResponse {
   items: AccountAsset[];
 }
@@ -98,11 +96,11 @@ export interface GetEstimateTransactionResponse {
     };
   };
 }
+
 export interface GetOperationListResponse {
   '@type': string;
   items: Operation[];
 }
-
 export interface GetOperationResponse {
   '@type': string;
   operation: Operation;
@@ -121,19 +119,21 @@ export interface GetOperationStatusResponse {
     externalVendorTransactionId?: string;
   };
 }
+
 export interface GetTokenResponse {
   code?: 'SUCCESS' | 'PROCESSING';
   accessToken: string;
   refreshToken: string;
   bootstrapToken: string;
 }
-
 export interface IDeviceStore {
   get(deviceId: string, key: string): Promise<string | null>;
   set(deviceId: string, key: string, value: string): Promise<void>;
   clear(deviceId: string, key: string): Promise<void>;
   getAllKeys(deviceId: string): Promise<string[]>;
 }
+
+export const MAX_RETRIES = 5;
 
 export interface Operation {
   '@type': string;

--- a/packages/ui-components/src/lib/types/fireBlocks.ts
+++ b/packages/ui-components/src/lib/types/fireBlocks.ts
@@ -1,3 +1,5 @@
+export const MAX_RETRIES = 5;
+
 export interface Account {
   '@type': string;
   id: string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5398,6 +5398,7 @@ __metadata:
     title-case: ^3.0.3
     truncate-eth-address: ^1.0.2
     truncate-middle: ^1.0.6
+    ts-retry: ^5.0.1
     tslib: ^2.6.2
     tss-react: ^4.0.0
     typescript: 5.0.4
@@ -20672,6 +20673,13 @@ __metadata:
     ts-node-transpile-only: dist/bin-transpile.js
     ts-script: dist/bin-script-deprecated.js
   checksum: 090adff1302ab20bd3486e6b4799e90f97726ed39e02b39e566f8ab674fd5bd5f727f43615debbfc580d33c6d9d1c6b1b3ce7d8e3cca3e20530a145ffa232c35
+  languageName: node
+  linkType: hard
+
+"ts-retry@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "ts-retry@npm:5.0.1"
+  checksum: 8cf23a09cd260e18baa5775a8220c482445c50fad0450d4b1b3e88a472e4486014140939dc7009db1081cdc5a32041ca8fb07ac3d0d3eb6d5be6dcf8b6b47f4a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Use the `ts-retry` package to wrap some common flaky failure paths in basic retry logic. Often when the client calls the wallet API backend, there are intermittent failures. The root cause on the wallet API failures is usually a Fireblocks upstream error, but calling the same API again after a short 100ms delay typically resolves the problem.

Used default retry count of 5.