### PR TITLE
Show wallet scoped valuation if available

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unstoppabledomains/ui-components",
-  "version": "0.0.50-browser-extension.12",
+  "version": "0.0.50-browser-extension.13",
   "private": true,
   "description": "An open and reusable suite of Unstoppable Domains management components",
   "keywords": [

--- a/packages/ui-components/src/components/Wallet/Client.tsx
+++ b/packages/ui-components/src/components/Wallet/Client.tsx
@@ -323,7 +323,9 @@ export const Client: React.FC<ClientProps> = ({
             DomainFieldTypes.Portfolio,
           ]);
           setDomainsValue(
-            (marketData?.portfolio?.account?.valueAmt || 0) / 100,
+            (marketData?.portfolio?.wallet?.valueAmt ||
+              marketData?.portfolio?.account?.valueAmt ||
+              0) / 100,
           );
         }
       }


### PR DESCRIPTION
Currently, the "domains" tab in Unstoppable Lite Wallet shows domain portfolio valuation. However, the valuation is scoped to the UD account associated with the wallet which is a confusing user experience. Update the rendering logic to show a valuation (if present) only for domains contained in the current wallet.