### PR TITLE
Validate token decimals before send

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unstoppabledomains/ui-components",
-  "version": "0.0.51-browser-extension.5",
+  "version": "0.0.51-browser-extension.6",
   "private": true,
   "description": "An open and reusable suite of Unstoppable Domains management components",
   "keywords": [

--- a/packages/ui-components/src/components/Wallet/Send.tsx
+++ b/packages/ui-components/src/components/Wallet/Send.tsx
@@ -274,7 +274,20 @@ const Send: React.FC<Props> = ({
   };
 
   const handleAmountChange = (value: string) => {
-    setAmount(value);
+    // validate an asset is selected
+    if (!accountAsset) {
+      return;
+    }
+
+    // normalize asset decimals if present
+    const normalizedValue = accountAsset.balance?.decimals
+      ? `0.${value
+          .replaceAll('0.', '')
+          .slice(0, accountAsset.balance.decimals)}`
+      : value;
+
+    // use normalized value
+    setAmount(normalizedValue);
   };
 
   if (isLoading) {

--- a/packages/ui-components/src/components/Wallet/Token.tsx
+++ b/packages/ui-components/src/components/Wallet/Token.tsx
@@ -5,7 +5,6 @@ import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
 import Typography from '@mui/material/Typography';
 import type {Theme} from '@mui/material/styles';
-import {useTheme} from '@mui/material/styles';
 import numeral from 'numeral';
 import React from 'react';
 import {Line} from 'react-chartjs-2';
@@ -120,8 +119,6 @@ const Token: React.FC<Props> = ({
   showGraph,
   hideBalance,
 }) => {
-  const theme = useTheme();
-
   const {classes, cx} = useStyles({
     palette: isOwner ? WalletPaletteOwner : WalletPalettePublic,
   });


### PR DESCRIPTION
The wallet service provides the max decimal length for each token. This value should be validated against user input to ensure only the expected number of decimals is provided to the backend. Otherwise a validation error will occur and the user cannot send their token.