### PR TITLE
Fix logic when generating link to block scanner page

### DIFF
--- a/server/pages/[domain]/index.page.tsx
+++ b/server/pages/[domain]/index.page.tsx
@@ -50,6 +50,7 @@ import truncateEthAddress from 'truncate-eth-address';
 import config from '@unstoppabledomains/config';
 import type {
   Blockchain,
+  CurrenciesType,
   DomainBadgesResponse,
   PersonaIdentity,
   SerializedCryptoWalletBadge,
@@ -91,6 +92,7 @@ import {
   TokensPortfolio,
   UnstoppableMessaging,
   formOpenSeaLink,
+  getBlockScanUrl,
   getDomainBadges,
   getFollowers,
   getHumanityCheckStatus,
@@ -303,12 +305,17 @@ const DomainProfile = ({
   };
 
   const handleOwnerAddressClick = () => {
-    window.open(
-      `https://www.oklink.com/${
-        profileData?.metadata?.blockchain === 'ETH' ? 'eth' : 'polygon'
-      }/address/${ownerAddress}?channelId=uns001`,
-      '_blank',
+    if (!profileData?.metadata?.blockchain) {
+      return;
+    }
+    const blockScanUrl = getBlockScanUrl(
+      profileData?.metadata?.blockchain as CurrenciesType,
+      ownerAddress,
     );
+    if (!blockScanUrl) {
+      return;
+    }
+    window.open(blockScanUrl, '_blank');
   };
 
   const handleViewFollowingClick = () => {


### PR DESCRIPTION
The profile page was not using the available `getBlockScanUrl()` method that already accounts for various chain formats. Using this method resolves the problem where domains minted on Base get linked to Polygon block scanner.