### PR TITLE
Solana SPL token support

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unstoppabledomains/config",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "private": true,
   "description": "Configuration variables for Unstoppable Domains environments",
   "homepage": "https://github.com/unstoppabledomains/domain-profiles#readme",

--- a/packages/config/src/env/default.ts
+++ b/packages/config/src/env/default.ts
@@ -62,7 +62,8 @@ export default function getDefaultConfig(): Config {
       SOL: {
         CHAIN_ID: 0,
         NETWORK_NAME: 'solana',
-        JSON_RPC_API_URL: '',
+        JSON_RPC_API_URL:
+          'https://solana-mainnet.g.alchemy.com/v2/NHnzEesdDuX90lFZRMOa4ZSE0wIR-BAo',
         BLOCK_EXPLORER_TX_URL: 'https://www.oklink.com/sol/tx/',
         BLOCK_EXPLORER_NAME: 'oklink',
         BLOCK_EXPLORER_BASE_URL: 'https://www.oklink.com/sol',

--- a/packages/config/src/env/production.ts
+++ b/packages/config/src/env/production.ts
@@ -37,6 +37,10 @@ export default function getProductionConfig(): ConfigOverride {
         PROXY_READER_ADDRESS: '0xA3f32c8cd786dc089Bd1fC175F2707223aeE5d00',
         OPEN_SEA_BASE_URL: 'https://opensea.io/assets/matic/',
       },
+      SOL: {
+        JSON_RPC_API_URL:
+          'https://solana-mainnet.g.alchemy.com/v2/NHnzEesdDuX90lFZRMOa4ZSE0wIR-BAo',
+      },
     },
     LOGIN_WITH_UNSTOPPABLE: {
       CLIENT_ID: 'c3af833f-3fd5-46fd-ac3e-bfc136624d1b',

--- a/packages/config/src/launchdarkly/defaultFlagValues.ts
+++ b/packages/config/src/launchdarkly/defaultFlagValues.ts
@@ -12,6 +12,7 @@ export const defaultFlagValues: LaunchDarklyFlagSet = {
   'ud-me-service-domains-enable-social-verification': false,
   'ud-me-service-domains-enable-management': false,
   'ud-me-service-domains-enable-fireblocks': false,
+  'ud-me-enable-wallet-solana-signing': false,
   'ud-me-service-enable-swap': false,
   'ecommerce-service-users-enable-chat-community-udBlue': false,
   'ecommerce-service-wallets-disable-badges': [],

--- a/packages/config/src/launchdarkly/keys.ts
+++ b/packages/config/src/launchdarkly/keys.ts
@@ -11,6 +11,7 @@ export type LaunchDarklyBooleanKey =
   | 'ud-me-service-domains-enable-social-verification'
   | 'ud-me-service-domains-enable-fireblocks'
   | 'ud-me-service-domains-enable-management'
+  | 'ud-me-enable-wallet-solana-signing'
   | 'ud-me-service-enable-swap';
 
 export type LaunchDarklyNumberKey = 'example-number';

--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unstoppabledomains/ui-components",
-  "version": "0.0.52-browser-extension.5",
+  "version": "0.0.52-browser-extension.6",
   "private": true,
   "description": "An open and reusable suite of Unstoppable Domains management components",
   "keywords": [
@@ -33,6 +33,7 @@
     "@mui/material": "5.10.4",
     "@pushprotocol/restapi": "1.6.6",
     "@pushprotocol/socket": "^0.5.1",
+    "@solana/spl-token": "^0.4.9",
     "@solana/wallet-adapter-phantom": "^0.9.9",
     "@solana/web3.js": "^1.50.1",
     "@swc/cli": "^0.1.57",

--- a/packages/ui-components/src/components/Wallet/SelectAsset.tsx
+++ b/packages/ui-components/src/components/Wallet/SelectAsset.tsx
@@ -59,6 +59,7 @@ type Props = {
   onClickBuy?: () => void;
   supportedAssetList: ImmutableArray<string>;
   supportErc20?: boolean;
+  supportSpl?: boolean;
 };
 
 export const SelectAsset: React.FC<Props> = ({
@@ -73,6 +74,7 @@ export const SelectAsset: React.FC<Props> = ({
   onClickBuy,
   supportedAssetList,
   supportErc20,
+  supportSpl,
 }) => {
   const {classes} = useStyles();
   const wallets = filterWallets(initialWallets, supportedAssetList);
@@ -82,6 +84,7 @@ export const SelectAsset: React.FC<Props> = ({
     .filter(
       token =>
         (token.type === TokenType.Erc20 && supportErc20) ||
+        (token.type === TokenType.Spl && supportSpl) ||
         supportedAssetList.includes(
           `${token.symbol.toUpperCase()}/${token.ticker.toUpperCase()}`,
         ),

--- a/packages/ui-components/src/hooks/useSubmitTransaction.ts
+++ b/packages/ui-components/src/hooks/useSubmitTransaction.ts
@@ -19,7 +19,14 @@ import type {AccountAsset, GetOperationResponse} from '../lib/types/fireBlocks';
 import {OperationStatusType} from '../lib/types/fireBlocks';
 import {getProviderUrl} from '../lib/wallet/evm/provider';
 import {createErc20TransferTx} from '../lib/wallet/evm/token';
+import {
+  broadcastTx,
+  createSplTransferTx,
+  signTransaction,
+  waitForTx,
+} from '../lib/wallet/solana/transaction';
 import useDomainConfig from './useDomainConfig';
+import useFireblocksMessageSigner from './useFireblocksMessageSigner';
 import useResolverKeys from './useResolverKeys';
 
 export type Params = {
@@ -51,6 +58,7 @@ export const useSubmitTransaction = ({
 }: Params) => {
   const {mappedResolverKeys} = useResolverKeys();
   const {setShowSuccessAnimation} = useDomainConfig();
+  const fireblocksMessageSigner = useFireblocksMessageSigner();
   const [transactionId, setTransactionId] = useState('');
   const [status, setStatus] = useState(Status.Pending);
   const [statusMessage, setStatusMessage] = useState<SendCryptoStatusMessage>(
@@ -118,9 +126,53 @@ export const useSubmitTransaction = ({
         recipientAddress = resolvedAddress;
       }
 
+      // handle an SPL token transfer
+      if (token.address && token.type === TokenType.Spl) {
+        try {
+          // create the transaction that must be signed
+          setStatusMessage(SendCryptoStatusMessage.STARTING_TRANSACTION);
+          const tx = await createSplTransferTx(
+            token.walletAddress,
+            recipientAddress,
+            token.address,
+            parseFloat(amount),
+            fireblocksMessageSigner,
+          );
+
+          // sign and wait for the signature value
+          setStatusMessage(SendCryptoStatusMessage.WAITING_TO_SIGN);
+          const signedTx = await signTransaction(
+            tx,
+            token.walletAddress,
+            fireblocksMessageSigner,
+            false,
+          );
+
+          // submit the transaction
+          setStatusMessage(SendCryptoStatusMessage.SUBMITTING_TRANSACTION);
+          const txHash = await broadcastTx(signedTx);
+
+          // wait for transaction confirmation
+          setStatusMessage(SendCryptoStatusMessage.WAITING_FOR_TRANSACTION);
+          setTransactionId(txHash);
+          await waitForTx(txHash);
+
+          // operation is complete
+          setStatusMessage(SendCryptoStatusMessage.TRANSACTION_COMPLETED);
+          setStatus(Status.Success);
+        } catch (e) {
+          notifyEvent(e, 'error', 'Wallet', 'Transaction', {
+            msg: 'error sending SPL token',
+            meta: {token, recipientAddress, amount},
+          });
+          setStatus(Status.Failed);
+        }
+        return;
+      }
+
       // create a transfer transaction if we are working with
-      // an ERC-20 token
-      const transferTx =
+      // an ERC-20 token on an EVM chain
+      const transferErc20Tx =
         asset.blockchainAsset.blockchain.networkId &&
         token.address &&
         token.type === TokenType.Erc20
@@ -137,12 +189,12 @@ export const useSubmitTransaction = ({
       // create new transfer request, depending on token type
       setStatusMessage(SendCryptoStatusMessage.STARTING_TRANSACTION);
       const operationResponse =
-        transferTx && asset.accountId
+        transferErc20Tx && asset.accountId
           ? await createTransactionOperation(
               accessToken,
               asset.accountId,
               asset.id,
-              transferTx,
+              transferErc20Tx,
             )
           : await getTransferOperationResponse(
               asset,

--- a/packages/ui-components/src/hooks/useSubmitTransaction.ts
+++ b/packages/ui-components/src/hooks/useSubmitTransaction.ts
@@ -154,6 +154,7 @@ export const useSubmitTransaction = ({
 
           // wait for transaction confirmation
           setStatusMessage(SendCryptoStatusMessage.WAITING_FOR_TRANSACTION);
+          setShowSuccessAnimation(true);
           setTransactionId(txHash);
           await waitForTx(txHash);
 

--- a/packages/ui-components/src/lib/types/domain.ts
+++ b/packages/ui-components/src/lib/types/domain.ts
@@ -480,7 +480,7 @@ export type SerializedWalletNftCollection = {
 };
 
 export type SerializedWalletToken = {
-  type: TokenType.Erc20 | TokenType.Native;
+  type: TokenType.Erc20 | TokenType.Native | TokenType.Spl;
   address: string;
   symbol: string;
   gasCurrency: string;
@@ -527,6 +527,7 @@ export type TelegramUserInfo = {
 export enum TokenType {
   Native = 'native',
   Erc20 = 'erc20',
+  Spl = 'spl',
   Nft = 'nft',
 }
 

--- a/packages/ui-components/src/lib/wallet/asset.ts
+++ b/packages/ui-components/src/lib/wallet/asset.ts
@@ -23,24 +23,28 @@ export const getAsset = (
   const asset = assets.find(a => {
     // use chain ID if provided
     if (opts?.chainId) {
-      return (
+      const chainAsset =
         SUPPORTED_SIGNING_SYMBOLS.includes(
           a.blockchainAsset.symbol.toUpperCase(),
-        ) && a.blockchainAsset.blockchain.networkId === opts.chainId
-      );
+        ) && a.blockchainAsset.blockchain.networkId === opts.chainId;
+      if (chainAsset) {
+        return chainAsset;
+      }
     }
 
     // use token if provided
     if (opts?.token) {
-      return (
+      const tokenAsset =
         a.blockchainAsset.blockchain.name.toLowerCase() ===
           opts.token.walletName.toLowerCase() &&
         a.blockchainAsset.symbol.toLowerCase() ===
           (opts.token.type === TokenType.Erc20
             ? opts.token.symbol.toLowerCase()
             : opts.token.ticker.toLowerCase()) &&
-        a.address.toLowerCase() === opts.token.walletAddress.toLowerCase()
-      );
+        a.address.toLowerCase() === opts.token.walletAddress.toLowerCase();
+      if (tokenAsset) {
+        return tokenAsset;
+      }
     }
 
     // find by address on default signing asset

--- a/packages/ui-components/src/lib/wallet/solana/provider.ts
+++ b/packages/ui-components/src/lib/wallet/solana/provider.ts
@@ -1,0 +1,7 @@
+import {Connection} from '@solana/web3.js';
+
+import {getProviderUrl} from '../evm/provider';
+
+export const getSolanaProvider = () => {
+  return new Connection(getProviderUrl('SOL'), 'confirmed');
+};

--- a/packages/ui-components/src/lib/wallet/solana/transaction.test.ts
+++ b/packages/ui-components/src/lib/wallet/solana/transaction.test.ts
@@ -1,0 +1,89 @@
+import {Keypair, PublicKey} from '@solana/web3.js';
+import {utils} from 'ethers';
+import nacl from 'tweetnacl';
+
+import {FireblocksMessageSigner} from '../../../hooks/useFireblocksMessageSigner';
+import {getSolanaProvider} from './provider';
+import {
+  createSplTransferTx,
+  getOrCreateAssociatedTokenAccountWithMPC,
+} from './transaction';
+
+describe('solana transactions', () => {
+  it('should create a transaction if destination token account exists', async () => {
+    const mockSigner = jest.fn();
+
+    const tx = await createSplTransferTx(
+      '8DyNeQYMWY6NLpPN7S1nTcDy2WXLnm5rzrtdWA2H2t6Y',
+      'HLAkHNm1qqGDZxyhoKGWPVwgXAaPSHA2fH5WKLouUJZT',
+      '7GCihgDB8fe6KNjn2MYtkzZcRjQy3t9GHdC8uHYmW2hr',
+      1,
+      mockSigner,
+    );
+    expect(tx).toBeDefined();
+    expect(mockSigner).not.toHaveBeenCalled();
+  });
+
+  it('should create a transaction if destination token is missing', async () => {
+    const mockSigner = jest.fn().mockImplementation((message: string) => {
+      return message;
+    });
+
+    await expect(
+      createSplTransferTx(
+        '8DyNeQYMWY6NLpPN7S1nTcDy2WXLnm5rzrtdWA2H2t6Y',
+        'HLAkHNm1qqGDZxyhoKGWPVwgXAaPSHA2fH5WKLouUJZT',
+        'EKpQGSJtjMFqKZ9KQanSqYXRcF8fBopzLHYxdM65zcjm',
+        1,
+        mockSigner,
+      ),
+    ).rejects.toThrow('Assertion failed');
+    expect(mockSigner).toHaveBeenCalledTimes(1);
+  });
+
+  it('should create a token account transaction', async () => {
+    const payer = Keypair.generate();
+    const rpcConnection = getSolanaProvider();
+
+    const mockSigner: FireblocksMessageSigner = async (message: string) => {
+      const messageBytes = Buffer.from(message.replace('0x', ''), 'hex');
+      const signature = nacl.sign.detached(messageBytes, payer.secretKey);
+      return utils.hexlify(signature);
+    };
+
+    await expect(
+      getOrCreateAssociatedTokenAccountWithMPC(
+        rpcConnection,
+        payer,
+        new PublicKey('EKpQGSJtjMFqKZ9KQanSqYXRcF8fBopzLHYxdM65zcjm'),
+        payer.publicKey,
+        mockSigner,
+        false,
+      ),
+    ).rejects.toThrow(/token account .+ tx was not broadcasted/);
+  });
+
+  it('should broadcast a token account transaction', async () => {
+    const payer = Keypair.generate();
+    const rpcConnection = getSolanaProvider();
+
+    const mockSigner: FireblocksMessageSigner = async (message: string) => {
+      const messageBytes = Buffer.from(message.replace('0x', ''), 'hex');
+      const signature = nacl.sign.detached(messageBytes, payer.secretKey);
+      return utils.hexlify(signature);
+    };
+
+    await expect(
+      getOrCreateAssociatedTokenAccountWithMPC(
+        rpcConnection,
+        payer,
+        new PublicKey('EKpQGSJtjMFqKZ9KQanSqYXRcF8fBopzLHYxdM65zcjm'),
+        payer.publicKey,
+        mockSigner,
+        true,
+      ),
+    ).rejects.toThrow(
+      'failed to send transaction: Transaction simulation failed: Attempt to debit an account but found no record of a prior credit.',
+    );
+  });
+});

--- a/packages/ui-components/src/lib/wallet/solana/transaction.ts
+++ b/packages/ui-components/src/lib/wallet/solana/transaction.ts
@@ -1,0 +1,251 @@
+import {
+  TokenAccountNotFoundError,
+  createAssociatedTokenAccountInstruction,
+  createTransferInstruction,
+  getAssociatedTokenAddressSync,
+  getOrCreateAssociatedTokenAccount,
+} from '@solana/spl-token';
+import {
+  Connection,
+  ParsedAccountData,
+  PublicKey,
+  Signer,
+  Transaction,
+  VersionedTransaction,
+} from '@solana/web3.js';
+import {utils} from 'ethers';
+
+import {FireblocksMessageSigner} from '../../../hooks/useFireblocksMessageSigner';
+import {notifyEvent} from '../../error';
+import {FB_MAX_RETRY, FB_WAIT_TIME_MS} from '../../fireBlocks/client';
+import {sleep} from '../../sleep';
+import {getSolanaProvider} from './provider';
+
+export const createSplTransferTx = async (
+  fromAddress: string,
+  toAddress: string,
+  tokenAddress: string,
+  amount: number,
+  signWithMpc: FireblocksMessageSigner,
+) => {
+  // retrieve a connection
+  const rpcProvider = getSolanaProvider();
+
+  // create public keys for associated accounts
+  const fromWalletSigner: Signer = {
+    publicKey: new PublicKey(fromAddress),
+    secretKey: new Uint8Array(),
+  };
+  const toWallet = new PublicKey(toAddress);
+  const tokenMint = new PublicKey(tokenAddress);
+
+  // get the token account of the from address, if it does not exist, create it
+  const fromTokenAccount = await getOrCreateAssociatedTokenAccountWithMPC(
+    rpcProvider,
+    fromWalletSigner,
+    tokenMint,
+    fromWalletSigner.publicKey,
+    signWithMpc,
+  );
+
+  // get the token account of the to address, if it does not exist, create it
+  const toTokenAccount = await getOrCreateAssociatedTokenAccountWithMPC(
+    rpcProvider,
+    fromWalletSigner,
+    tokenMint,
+    toWallet,
+    signWithMpc,
+  );
+
+  // Add token transfer instructions to transaction. The lastBlockHash is important
+  // to ensure the tx is valid, and can only be used for about 60–90 seconds before
+  // it's considered expired. This means if it takes too long to generate a signature
+  // the transaction will fail.
+  const [latestBlockhash, tokenDecimals] = await Promise.all([
+    rpcProvider.getLatestBlockhash(),
+    getTokenDecimals(rpcProvider, tokenMint),
+  ]);
+  const transaction = new Transaction({
+    feePayer: fromWalletSigner.publicKey,
+    ...latestBlockhash,
+  }).add(
+    createTransferInstruction(
+      fromTokenAccount.address,
+      toTokenAccount.address,
+      fromWalletSigner.publicKey,
+      amount * Math.pow(10, tokenDecimals),
+    ),
+  );
+  return transaction;
+};
+
+export const getOrCreateAssociatedTokenAccountWithMPC = async (
+  connection: Connection,
+  payer: Signer,
+  mint: PublicKey,
+  owner: PublicKey,
+  signWithMpc: FireblocksMessageSigner,
+  broadcast: boolean = true,
+) => {
+  try {
+    notifyEvent('retrieving token account', 'info', 'Wallet', 'Transaction', {
+      meta: {
+        payer: payer.publicKey,
+        owner: owner.toBase58(),
+        token: mint.toBase58(),
+        broadcast,
+      },
+    });
+    return await getOrCreateAssociatedTokenAccount(
+      connection,
+      payer,
+      mint,
+      owner,
+    );
+  } catch (e) {
+    if (e instanceof TokenAccountNotFoundError) {
+      // create a transaction to create the token account if it is missing
+      const associatedToken = getAssociatedTokenAddressSync(mint, owner);
+      const latestBlockhash = await connection.getLatestBlockhash();
+      notifyEvent('creating token account', 'info', 'Wallet', 'Transaction', {
+        meta: {
+          payer: payer.publicKey,
+          owner: owner.toBase58(),
+          token: mint.toBase58(),
+          associatedToken,
+          latestBlockhash,
+          broadcast,
+        },
+      });
+      const associatedTokenTx = new Transaction({
+        feePayer: payer.publicKey,
+        ...latestBlockhash,
+      }).add(
+        createAssociatedTokenAccountInstruction(
+          payer.publicKey,
+          associatedToken,
+          owner,
+          mint,
+        ),
+      );
+
+      // sign the transaction to create token account
+      await signTransaction(
+        associatedTokenTx,
+        payer.publicKey.toBase58(),
+        signWithMpc,
+        broadcast,
+      );
+
+      // retrieve the newly created associated account
+      if (broadcast) {
+        return await getOrCreateAssociatedTokenAccount(
+          connection,
+          payer,
+          mint,
+          owner,
+        );
+      }
+      throw new Error(
+        `token account ${associatedToken.toBase58()} tx was not broadcasted`,
+      );
+    }
+    throw e;
+  }
+};
+
+export const getTokenDecimals = async (
+  rpcConnection: Connection,
+  tokenMint: PublicKey,
+): Promise<number> => {
+  const info = await rpcConnection.getParsedAccountInfo(tokenMint);
+  const result = (info.value?.data as ParsedAccountData).parsed.info
+    .decimals as number;
+  return result;
+};
+
+export const signTransaction = async (
+  tx: Transaction | VersionedTransaction,
+  signerAddress: string,
+  signWithMpc: FireblocksMessageSigner,
+  broadcast?: boolean,
+): Promise<Transaction | VersionedTransaction> => {
+  // retrieve the tx message that must be signed depending on the format
+  const txMessageBuffer = isVersionedTransaction(tx)
+    ? tx.message.serialize()
+    : tx.serializeMessage();
+  const txMessage = utils.hexlify(txMessageBuffer);
+
+  // sign the message
+  notifyEvent('sign tx start', 'info', 'Wallet', 'Signature', {
+    meta: {txMessage, tx},
+  });
+  const signature = await signWithMpc(txMessage, signerAddress);
+
+  // append the signature to the transaction
+  notifyEvent('sign tx complete', 'info', 'Wallet', 'Signature', {
+    meta: {signature},
+  });
+  tx.addSignature(
+    new PublicKey(signerAddress),
+    Buffer.from(signature.replace('0x', ''), 'hex'),
+  );
+
+  // broadcast the tx if requested
+  if (broadcast) {
+    const txHash = await broadcastTx(tx);
+    await waitForTx(txHash);
+  }
+
+  // return the signed transaction
+  return tx;
+};
+
+export const broadcastTx = async (tx: Transaction | VersionedTransaction) => {
+  // broadcast the raw transaction
+  const rpcConnection = getSolanaProvider();
+  notifyEvent('broadcast tx start', 'info', 'Wallet', 'Signature', {
+    meta: {tx},
+  });
+  const txHash = await rpcConnection.sendRawTransaction(tx.serialize());
+  notifyEvent('broadcast tx complete', 'info', 'Wallet', 'Signature', {
+    meta: {txHash},
+  });
+
+  return txHash;
+};
+
+export const waitForTx = async (txHash: string) => {
+  // wait for confirmation
+  const rpcConnection = getSolanaProvider();
+  notifyEvent('confirm tx start', 'info', 'Wallet', 'Signature', {
+    meta: {txHash},
+  });
+  for (let i = 0; i < FB_MAX_RETRY; i++) {
+    try {
+      const info = await rpcConnection.getTransaction(txHash, {
+        commitment: 'confirmed',
+        maxSupportedTransactionVersion: 0,
+      });
+      notifyEvent('retrieved tx info', 'info', 'Wallet', 'Transaction', {
+        meta: {txHash, info},
+      });
+      if (info) {
+        break;
+      }
+    } catch (e) {
+      notifyEvent(e, 'warning', 'Wallet', 'Transaction', {meta: {txHash}});
+    }
+    await sleep(FB_WAIT_TIME_MS);
+  }
+
+  notifyEvent('confirm tx complete', 'info', 'Wallet', 'Signature', {
+    meta: {txHash},
+  });
+};
+
+export const isVersionedTransaction = (
+  transaction: Transaction | VersionedTransaction,
+): transaction is VersionedTransaction => {
+  return 'version' in transaction;
+};

--- a/server.jest.config.ts
+++ b/server.jest.config.ts
@@ -1,4 +1,11 @@
+import {lstatSync, readdirSync} from 'fs';
+import path from 'path';
 import type {InitialOptionsTsJest} from 'ts-jest/dist/types';
+
+const sharedBasePath = path.resolve(__dirname, 'packages');
+const sharedModules = readdirSync(sharedBasePath).filter(name => {
+  return lstatSync(path.join(sharedBasePath, name)).isDirectory();
+});
 
 const config: InitialOptionsTsJest = {
   preset: 'ts-jest',
@@ -16,6 +23,17 @@ const config: InitialOptionsTsJest = {
     ],
   },
   testPathIgnorePatterns: ['/node_modules/', '/build/', '/e2e/'],
+  moduleNameMapper: {
+    ['@bugsnag/(.*)']: '<rootDir>/tests/mocks/empty.js',
+    ...sharedModules.reduce(
+      (acc, name) => ({
+        ...acc,
+        [`@unstoppabledomains/${name}/src/(.*)$`]: `<rootDir>/packages/${name}/src/$1`,
+        [`@unstoppabledomains/${name}(.*)$`]: `<rootDir>/packages/${name}/src/$1`,
+      }),
+      {},
+    ),
+  },
 };
 
 export default config;

--- a/tests/setupTests.ts
+++ b/tests/setupTests.ts
@@ -1,15 +1,18 @@
 import dotenv from 'dotenv';
-import jestFetchMock from 'jest-fetch-mock';
+
+//import jestFetchMock from 'jest-fetch-mock';
 
 // Adds the 'fetchMock' global variable and rewires 'fetch' global to call 'fetchMock'
 // instead of the real implementation. Throws an exception if a call to fetch() is not
 // encountered, which means an action was not mocked by the unit test.
+/*
 jestFetchMock.enableMocks();
 jestFetchMock.mockImplementation((url: any) => {
   throw new Error(
     `The test called fetch(${url}) unexpectedly. Ensure you mock all network requests through client actions.`,
   );
 });
+*/
 
 dotenv.config({
   path: __dirname + '/.env.test',

--- a/yarn.lock
+++ b/yarn.lock
@@ -505,6 +505,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.25.0":
+  version: 7.26.0
+  resolution: "@babel/runtime@npm:7.26.0"
+  dependencies:
+    regenerator-runtime: ^0.14.0
+  checksum: c8e2c0504ab271b3467a261a8f119bf2603eb857a0d71e37791f4e3fae00f681365073cc79f141ddaa90c6077c60ba56448004ad5429d07ac73532be9f7cf28a
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.12.13, @babel/template@npm:^7.22.15, @babel/template@npm:^7.3.3":
   version: 7.22.15
   resolution: "@babel/template@npm:7.22.15"
@@ -2936,6 +2945,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@noble/curves@npm:^1.4.2":
+  version: 1.7.0
+  resolution: "@noble/curves@npm:1.7.0"
+  dependencies:
+    "@noble/hashes": 1.6.0
+  checksum: e220b704f1e516f326fff985e794e840a267f5542e1388737142b08177672ebc41b460b5a5bf636d7622c68e8ae719bc042ccd8aed16dc14311450a94b5f2a05
+  languageName: node
+  linkType: hard
+
 "@noble/ed25519@npm:^1.5.1, @noble/ed25519@npm:^1.7.3":
   version: 1.7.3
   resolution: "@noble/ed25519@npm:1.7.3"
@@ -2957,10 +2975,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@noble/hashes@npm:1.6.0":
+  version: 1.6.0
+  resolution: "@noble/hashes@npm:1.6.0"
+  checksum: 07729b80108d2a9b862eb4e070d4f78ca7ee86b9a9c13a4f7c338ba47a15d4386dd283235da71f21ad515fa9f0b9429fc3da39d2f2b4a50e2442212d14cfd4a9
+  languageName: node
+  linkType: hard
+
 "@noble/hashes@npm:^1.1.5, @noble/hashes@npm:^1.2.0, @noble/hashes@npm:^1.3.2":
   version: 1.3.3
   resolution: "@noble/hashes@npm:1.3.3"
   checksum: 8a6496d1c0c64797339bc694ad06cdfaa0f9e56cd0c3f68ae3666cfb153a791a55deb0af9c653c7ed2db64d537aa3e3054629740d2f2338bb1dcb7ab60cd205b
+  languageName: node
+  linkType: hard
+
+"@noble/hashes@npm:^1.4.0":
+  version: 1.6.1
+  resolution: "@noble/hashes@npm:1.6.1"
+  checksum: 57c62f65ee217c0293b4321b547792aa6d79812bfe70a7d62dc83e0f936cc677b14ed981b4e88cf8fdad37cd6d3a0cbd3bd0908b0728adc9daf066e678be8901
   languageName: node
   linkType: hard
 
@@ -3514,12 +3546,155 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@solana/buffer-layout@npm:^4.0.0":
+"@solana/buffer-layout-utils@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "@solana/buffer-layout-utils@npm:0.2.0"
+  dependencies:
+    "@solana/buffer-layout": ^4.0.0
+    "@solana/web3.js": ^1.32.0
+    bigint-buffer: ^1.1.5
+    bignumber.js: ^9.0.1
+  checksum: 9284242245b18b49577195ba7548263850be865a4a2d183944fa01bb76382039db589aab8473698e9bb734b515ada9b4d70db0a72e341c5d567c59b83d6d0840
+  languageName: node
+  linkType: hard
+
+"@solana/buffer-layout@npm:^4.0.0, @solana/buffer-layout@npm:^4.0.1":
   version: 4.0.1
   resolution: "@solana/buffer-layout@npm:4.0.1"
   dependencies:
     buffer: ~6.0.3
   checksum: bf846888e813187243d4008a7a9f58b49d16cbd995b9d7f1b72898aa510ed77b1ce5e8468e7b2fd26dd81e557a4e74a666e21fccb95f123c1f740d41138bbacd
+  languageName: node
+  linkType: hard
+
+"@solana/codecs-core@npm:2.0.0-rc.1":
+  version: 2.0.0-rc.1
+  resolution: "@solana/codecs-core@npm:2.0.0-rc.1"
+  dependencies:
+    "@solana/errors": 2.0.0-rc.1
+  peerDependencies:
+    typescript: ">=5"
+  checksum: e3a138cbdc2b87c6296c449384b684ca2f90cf212cee1cf0a1f30385c3acc72c9a3dc2e60e3152723b9fa5640635bcf69ce06581d83113986ede05d41139f0ba
+  languageName: node
+  linkType: hard
+
+"@solana/codecs-data-structures@npm:2.0.0-rc.1":
+  version: 2.0.0-rc.1
+  resolution: "@solana/codecs-data-structures@npm:2.0.0-rc.1"
+  dependencies:
+    "@solana/codecs-core": 2.0.0-rc.1
+    "@solana/codecs-numbers": 2.0.0-rc.1
+    "@solana/errors": 2.0.0-rc.1
+  peerDependencies:
+    typescript: ">=5"
+  checksum: 7c24700be7c935fc066dc70e1a02c32d9f17393d3898074e6dcff2c2083012dc8c5583fff5ee04f8ce4578c57bb708688f5e52aad301aa5543aab293640a0b21
+  languageName: node
+  linkType: hard
+
+"@solana/codecs-numbers@npm:2.0.0-rc.1":
+  version: 2.0.0-rc.1
+  resolution: "@solana/codecs-numbers@npm:2.0.0-rc.1"
+  dependencies:
+    "@solana/codecs-core": 2.0.0-rc.1
+    "@solana/errors": 2.0.0-rc.1
+  peerDependencies:
+    typescript: ">=5"
+  checksum: 370c1f94970e969b1f523d47714ddd751b68f622967455e2376590af0f230e027dce365bd54a9017fbc064ed21447f795c775c46285222c42a11b8ed46a41570
+  languageName: node
+  linkType: hard
+
+"@solana/codecs-strings@npm:2.0.0-rc.1":
+  version: 2.0.0-rc.1
+  resolution: "@solana/codecs-strings@npm:2.0.0-rc.1"
+  dependencies:
+    "@solana/codecs-core": 2.0.0-rc.1
+    "@solana/codecs-numbers": 2.0.0-rc.1
+    "@solana/errors": 2.0.0-rc.1
+  peerDependencies:
+    fastestsmallesttextencoderdecoder: ^1.0.22
+    typescript: ">=5"
+  checksum: 0706605311508b02f7dc4bfde6f93237337ecde051c83f172a121b52676e2a21af90f916624f57c0e80bbe420412ed98c1e7ae90a583761b028cc6a883fa4a0e
+  languageName: node
+  linkType: hard
+
+"@solana/codecs@npm:2.0.0-rc.1":
+  version: 2.0.0-rc.1
+  resolution: "@solana/codecs@npm:2.0.0-rc.1"
+  dependencies:
+    "@solana/codecs-core": 2.0.0-rc.1
+    "@solana/codecs-data-structures": 2.0.0-rc.1
+    "@solana/codecs-numbers": 2.0.0-rc.1
+    "@solana/codecs-strings": 2.0.0-rc.1
+    "@solana/options": 2.0.0-rc.1
+  peerDependencies:
+    typescript: ">=5"
+  checksum: 8586abfd1e2792008a447c29efc22e0bfefd7d97a8025090dd49ec07c8c860e51c44355ab74faf43e23336f3dd2e1353238fa4b009d3fe60ff3f02b46a96aa04
+  languageName: node
+  linkType: hard
+
+"@solana/errors@npm:2.0.0-rc.1":
+  version: 2.0.0-rc.1
+  resolution: "@solana/errors@npm:2.0.0-rc.1"
+  dependencies:
+    chalk: ^5.3.0
+    commander: ^12.1.0
+  peerDependencies:
+    typescript: ">=5"
+  bin:
+    errors: bin/cli.mjs
+  checksum: 906892a892d250c2236449b875b174e0e19ade788146d0e63da23c83d89b98a762770c276341fae8f73959efc57d01090e0e979d111b12ac0e451f2402a8d092
+  languageName: node
+  linkType: hard
+
+"@solana/options@npm:2.0.0-rc.1":
+  version: 2.0.0-rc.1
+  resolution: "@solana/options@npm:2.0.0-rc.1"
+  dependencies:
+    "@solana/codecs-core": 2.0.0-rc.1
+    "@solana/codecs-data-structures": 2.0.0-rc.1
+    "@solana/codecs-numbers": 2.0.0-rc.1
+    "@solana/codecs-strings": 2.0.0-rc.1
+    "@solana/errors": 2.0.0-rc.1
+  peerDependencies:
+    typescript: ">=5"
+  checksum: 63f3ed04e56ca232023fcf35ddab8f01a1ba7aae932990908657dec833ff4133ad0af279417d4bce291367903dbd3b962287796a22dd0aaa1d3e3290613a442e
+  languageName: node
+  linkType: hard
+
+"@solana/spl-token-group@npm:^0.0.7":
+  version: 0.0.7
+  resolution: "@solana/spl-token-group@npm:0.0.7"
+  dependencies:
+    "@solana/codecs": 2.0.0-rc.1
+  peerDependencies:
+    "@solana/web3.js": ^1.95.3
+  checksum: 8a47c409ca185d89c6572848a2a496ad3f70ef7b1efac2960b06836996870c861d3c8d920032451c9dda90765c7a4b484d883449331fdf859911436bfe9e2ad6
+  languageName: node
+  linkType: hard
+
+"@solana/spl-token-metadata@npm:^0.1.6":
+  version: 0.1.6
+  resolution: "@solana/spl-token-metadata@npm:0.1.6"
+  dependencies:
+    "@solana/codecs": 2.0.0-rc.1
+  peerDependencies:
+    "@solana/web3.js": ^1.95.3
+  checksum: a19d7d659c3fca375312e86cf4b0a2077327b220462b46a8627f0cc1892c97ce34cfbe9c3645620496d7b1177d56628b16a7357cd61314e079c1d9c73c944d98
+  languageName: node
+  linkType: hard
+
+"@solana/spl-token@npm:^0.4.9":
+  version: 0.4.9
+  resolution: "@solana/spl-token@npm:0.4.9"
+  dependencies:
+    "@solana/buffer-layout": ^4.0.0
+    "@solana/buffer-layout-utils": ^0.2.0
+    "@solana/spl-token-group": ^0.0.7
+    "@solana/spl-token-metadata": ^0.1.6
+    buffer: ^6.0.3
+  peerDependencies:
+    "@solana/web3.js": ^1.95.3
+  checksum: a1b0433786cff28755cf0ba219dc6e9805f11acd717a0285116445cc60acc0153af5d422c5ffeac429e9d2ebab66045f8d736cc8999d68f60ed317ec2e9bcaea
   languageName: node
   linkType: hard
 
@@ -3555,6 +3730,29 @@ __metadata:
     "@wallet-standard/base": ^1.0.1
     "@wallet-standard/features": ^1.0.3
   checksum: fc55221bfe006397908bcd951d03e85afc76947207554d5c77b4043f0776c25fb47e3609f6fa5aaad3120a526a351316402ffd4682dcdc23ec13c2b22b5f1970
+  languageName: node
+  linkType: hard
+
+"@solana/web3.js@npm:^1.32.0":
+  version: 1.95.8
+  resolution: "@solana/web3.js@npm:1.95.8"
+  dependencies:
+    "@babel/runtime": ^7.25.0
+    "@noble/curves": ^1.4.2
+    "@noble/hashes": ^1.4.0
+    "@solana/buffer-layout": ^4.0.1
+    agentkeepalive: ^4.5.0
+    bigint-buffer: ^1.1.5
+    bn.js: ^5.2.1
+    borsh: ^0.7.0
+    bs58: ^4.0.1
+    buffer: 6.0.3
+    fast-stable-stringify: ^1.0.0
+    jayson: ^4.1.1
+    node-fetch: ^2.7.0
+    rpc-websockets: ^9.0.2
+    superstruct: ^2.0.2
+  checksum: 875a65c2e16ea797b2a1e842fe9a53ae74f627b8678d946a12f4a6acd1922dfcb107429b2b6d93131d406d30deffaa366132fe9b87dbf0b62c7b83e83184b3fa
   languageName: node
   linkType: hard
 
@@ -3934,6 +4132,15 @@ __metadata:
   dependencies:
     tslib: ^2.4.0
   checksum: 736857d524b41a8a4db81094e9b027f554004e0fa3e86325d85bdb38f7e6459ce022db079edb6c61ba0f46fe8583b3e663e95f7acbd13e51b8da6c34e45bba2e
+  languageName: node
+  linkType: hard
+
+"@swc/helpers@npm:^0.5.11":
+  version: 0.5.15
+  resolution: "@swc/helpers@npm:0.5.15"
+  dependencies:
+    tslib: ^2.8.0
+  checksum: 1a9e0dbb792b2d1e0c914d69c201dbc96af3a0e6e6e8cf5a7f7d6a5d7b0e8b762915cd4447acb6b040e2ecc1ed49822875a7239f99a2d63c96c3c3407fb6fccf
   languageName: node
   linkType: hard
 
@@ -5070,6 +5277,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/uuid@npm:^8.3.4":
+  version: 8.3.4
+  resolution: "@types/uuid@npm:8.3.4"
+  checksum: 6f11f3ff70f30210edaa8071422d405e9c1d4e53abbe50fdce365150d3c698fe7bbff65c1e71ae080cbfb8fded860dbb5e174da96fdbbdfcaa3fb3daa474d20f
+  languageName: node
+  linkType: hard
+
 "@types/ws@npm:8.5.3":
   version: 8.5.3
   resolution: "@types/ws@npm:8.5.3"
@@ -5085,6 +5299,15 @@ __metadata:
   dependencies:
     "@types/node": "*"
   checksum: b4c9b8ad209620c9b21e78314ce4ff07515c0cadab9af101c1651e7bfb992d7fd933bd8b9c99d110738fd6db523ed15f82f29f50b45510288da72e964dedb1a3
+  languageName: node
+  linkType: hard
+
+"@types/ws@npm:^8.2.2":
+  version: 8.5.13
+  resolution: "@types/ws@npm:8.5.13"
+  dependencies:
+    "@types/node": "*"
+  checksum: f17023ce7b89c6124249c90211803a4aaa02886e12bc2d0d2cd47fa665eeb058db4d871ce4397d8e423f6beea97dd56835dd3fdbb921030fe4d887601e37d609
   languageName: node
   linkType: hard
 
@@ -5366,6 +5589,7 @@ __metadata:
     "@mui/material": 5.10.4
     "@pushprotocol/restapi": 1.6.6
     "@pushprotocol/socket": ^0.5.1
+    "@solana/spl-token": ^0.4.9
     "@solana/wallet-adapter-phantom": ^0.9.9
     "@solana/web3.js": ^1.50.1
     "@swc/cli": ^0.1.57
@@ -6640,7 +6864,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"agentkeepalive@npm:^4.2.1, agentkeepalive@npm:^4.3.0":
+"agentkeepalive@npm:^4.2.1, agentkeepalive@npm:^4.3.0, agentkeepalive@npm:^4.5.0":
   version: 4.5.0
   resolution: "agentkeepalive@npm:4.5.0"
   dependencies:
@@ -7369,7 +7593,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bignumber.js@npm:^9.0.0":
+"bignumber.js@npm:^9.0.0, bignumber.js@npm:^9.0.1":
   version: 9.1.2
   resolution: "bignumber.js@npm:9.1.2"
   checksum: 582c03af77ec9cb0ebd682a373ee6c66475db94a4325f92299621d544aa4bd45cb45fd60001610e94aef8ae98a0905fa538241d9638d4422d57abbeeac6fadaf
@@ -8081,7 +8305,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:5.3.0":
+"chalk@npm:5.3.0, chalk@npm:^5.3.0":
   version: 5.3.0
   resolution: "chalk@npm:5.3.0"
   checksum: 623922e077b7d1e9dedaea6f8b9e9352921f8ae3afe739132e0e00c275971bdd331268183b2628cf4ab1727c45ea1f28d7e24ac23ce1db1eb653c414ca8a5a80
@@ -8489,6 +8713,13 @@ __metadata:
   version: 11.0.0
   resolution: "commander@npm:11.0.0"
   checksum: 6621954e1e1d078b4991c1f5bbd9439ad37aa7768d6ab4842de1dbd4d222c8a27e1b8e62108b3a92988614af45031d5bb2a2aaa92951f4d0c934d1a1ac564bb4
+  languageName: node
+  linkType: hard
+
+"commander@npm:^12.1.0":
+  version: 12.1.0
+  resolution: "commander@npm:12.1.0"
+  checksum: 68e9818b00fc1ed9cdab9eb16905551c2b768a317ae69a5e3c43924c2b20ac9bb65b27e1cab36aeda7b6496376d4da908996ba2c0b5d79463e0fb1e77935d514
   languageName: node
   linkType: hard
 
@@ -13490,6 +13721,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jayson@npm:^4.1.1":
+  version: 4.1.3
+  resolution: "jayson@npm:4.1.3"
+  dependencies:
+    "@types/connect": ^3.4.33
+    "@types/node": ^12.12.54
+    "@types/ws": ^7.4.4
+    JSONStream: ^1.3.5
+    commander: ^2.20.3
+    delay: ^5.0.0
+    es6-promisify: ^5.0.0
+    eyes: ^0.1.8
+    isomorphic-ws: ^4.0.1
+    json-stringify-safe: ^5.0.1
+    uuid: ^8.3.2
+    ws: ^7.5.10
+  bin:
+    jayson: bin/jayson.js
+  checksum: 3e9e0e3d5c14d7a4a85ddfc372236c9938ed713affe58e9ef61e31f075d89947c4d206a2489c5355ff5a639b8cef42906844b9ca8cad48d8147c8132480a242b
+  languageName: node
+  linkType: hard
+
 "jest-canvas-mock@npm:^2.3.1":
   version: 2.5.2
   resolution: "jest-canvas-mock@npm:2.5.2"
@@ -16497,7 +16750,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.12, node-fetch@npm:^2.6.8":
+"node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.12, node-fetch@npm:^2.6.8, node-fetch@npm:^2.7.0":
   version: 2.7.0
   resolution: "node-fetch@npm:2.7.0"
   dependencies:
@@ -18926,6 +19179,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rpc-websockets@npm:^9.0.2":
+  version: 9.0.4
+  resolution: "rpc-websockets@npm:9.0.4"
+  dependencies:
+    "@swc/helpers": ^0.5.11
+    "@types/uuid": ^8.3.4
+    "@types/ws": ^8.2.2
+    buffer: ^6.0.3
+    bufferutil: ^4.0.1
+    eventemitter3: ^5.0.1
+    utf-8-validate: ^5.0.2
+    uuid: ^8.3.2
+    ws: ^8.5.0
+  dependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: d5efe3a1e7fbd9858886342fb766c05ac69c645bfb3c39a907425163db33e237ae2a601b62e17451040584c06d8699152fb2311a7d6cded2a7e7d4e0e74f0c1a
+  languageName: node
+  linkType: hard
+
 "run-applescript@npm:^5.0.0":
   version: 5.0.0
   resolution: "run-applescript@npm:5.0.0"
@@ -20252,6 +20527,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"superstruct@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "superstruct@npm:2.0.2"
+  checksum: a5f75b72cb8b14b86f4f7f750dae8c5ab0e4e1d92414b55e7625bae07bbcafad81c92486e7e32ccacd6ae1f553caff2b92a50ff42ad5093fd35b9cb7f4e5ec86
+  languageName: node
+  linkType: hard
+
 "supports-color@npm:^2.0.0":
   version: 2.0.0
   resolution: "supports-color@npm:2.0.0"
@@ -20883,6 +21165,13 @@ __metadata:
   version: 2.6.2
   resolution: "tslib@npm:2.6.2"
   checksum: 329ea56123005922f39642318e3d1f0f8265d1e7fcb92c633e0809521da75eeaca28d2cf96d7248229deb40e5c19adf408259f4b9640afd20d13aecc1430f3ad
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^2.8.0":
+  version: 2.8.1
+  resolution: "tslib@npm:2.8.1"
+  checksum: e4aba30e632b8c8902b47587fd13345e2827fa639e7c3121074d5ee0880723282411a8838f830b55100cbe4517672f84a2472667d355b81e8af165a55dc6203a
   languageName: node
   linkType: hard
 
@@ -22892,6 +23181,21 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: c3c100a181b731f40b7f2fddf004aa023f79d64f489706a28bc23ff88e87f6a64b3c6651fbec3a84a53960b75159574d7a7385709847a62ddb7ad6af76f49138
+  languageName: node
+  linkType: hard
+
+"ws@npm:^7.5.10":
+  version: 7.5.10
+  resolution: "ws@npm:7.5.10"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ^5.0.2
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: f9bb062abf54cc8f02d94ca86dcd349c3945d63851f5d07a3a61c2fcb755b15a88e943a63cf580cbdb5b74436d67ef6b67f745b8f7c0814e411379138e1863cb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds the ability to send Solana SPL tokens, as well as sign Solana messages and transactions. Gated by feature flag `ud-me-enable-wallet-solana-signing`.