### PR TITLE
Refresh access token in background

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unstoppabledomains/ui-components",
-  "version": "0.0.53-browser-extension.15",
+  "version": "0.0.53-browser-extension.16",
   "private": true,
   "description": "An open and reusable suite of Unstoppable Domains management components",
   "keywords": [

--- a/packages/ui-components/src/actions/fireBlocksActions.ts
+++ b/packages/ui-components/src/actions/fireBlocksActions.ts
@@ -380,7 +380,7 @@ export const getAccounts = async (
 ): Promise<GetAccountsResponse | undefined> => {
   try {
     // retrieve a new set of tokens using the refresh token
-    return await fetchApi<GetAccountsResponse>('/v1/accounts', {
+    const accounts = await fetchApi<GetAccountsResponse>('/v1/accounts', {
       mode: 'cors',
       headers: {
         'Access-Control-Allow-Credentials': 'true',
@@ -389,6 +389,9 @@ export const getAccounts = async (
       },
       host: config.WALLETS.HOST_URL,
     });
+    if (accounts.items.length > 0) {
+      return accounts;
+    }
   } catch (e) {
     notifyEvent(e, 'error', 'Wallet', 'Fetch', {
       msg: 'error retrieving accounts',

--- a/packages/ui-components/src/components/Wallet/SecurityCenterModal.tsx
+++ b/packages/ui-components/src/components/Wallet/SecurityCenterModal.tsx
@@ -513,6 +513,7 @@ const SecurityCenterModal: React.FC<Props> = ({accessToken}) => {
       )}
       {isMfaModalOpen && (
         <TwoFactorModal
+          accessToken={accessToken}
           emailAddress="no-reply@unstoppabledomains.com"
           enabled={isMfaEnabled}
           open={isMfaModalOpen}

--- a/packages/ui-components/src/components/Wallet/Swap.tsx
+++ b/packages/ui-components/src/components/Wallet/Swap.tsx
@@ -64,7 +64,7 @@ import {
   signTransaction,
   waitForTx,
 } from '../../lib/wallet/solana/transaction';
-import {localStorageWrapper} from '../Chat';
+import {isEthAddress, localStorageWrapper} from '../Chat';
 import ManageInput from '../Manage/common/ManageInput';
 import {
   getBlockchainDisplaySymbol,
@@ -411,6 +411,12 @@ const Swap: React.FC<Props> = ({
     return {
       swing: {
         chain: token.chain,
+        chainId: isEthAddress(token.address)
+          ? config.WALLETS.SWAP.SUPPORTED_TOKENS.SOURCE.find(
+              tConfig =>
+                tConfig.swing.chain.toLowerCase() === token.chain.toLowerCase(),
+            )?.swing.chainId
+          : undefined,
         symbol: token.address,
         type: isNative ? 'native' : token.chain === 'solana' ? 'spl' : 'erc20',
       },

--- a/packages/ui-components/src/components/Wallet/TwoFactorModal.tsx
+++ b/packages/ui-components/src/components/Wallet/TwoFactorModal.tsx
@@ -13,7 +13,6 @@ import {
   getTwoFactorChallenge,
   verifyTwoFactorChallenge,
 } from '../../actions/walletMfaActions';
-import {useFireblocksAccessToken} from '../../hooks';
 import ManageInput from '../Manage/common/ManageInput';
 import Modal from '../Modal';
 
@@ -43,6 +42,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
 }));
 
 interface TwoFactorModalProps {
+  accessToken?: string;
   emailAddress: string;
   enabled?: boolean;
   open?: boolean;
@@ -51,6 +51,7 @@ interface TwoFactorModalProps {
 }
 
 export const TwoFactorModal: React.FC<TwoFactorModalProps> = ({
+  accessToken,
   emailAddress,
   enabled = false,
   open,
@@ -58,18 +59,9 @@ export const TwoFactorModal: React.FC<TwoFactorModalProps> = ({
   onUpdated,
 }) => {
   const {classes, cx} = useStyles();
-  const getAccessToken = useFireblocksAccessToken();
-  const [accessToken, setAccessToken] = useState('');
   const [qrCodeContent, setQrCodeContent] = useState<string>();
   const [errorMessage, setErrorMessage] = useState<string>();
   const [otp, setOtp] = useState<string>();
-
-  useEffect(() => {
-    const loadAccessToken = async () => {
-      setAccessToken(await getAccessToken());
-    };
-    void loadAccessToken();
-  }, []);
 
   useEffect(() => {
     if (!accessToken || !emailAddress) {
@@ -99,7 +91,7 @@ export const TwoFactorModal: React.FC<TwoFactorModalProps> = ({
 
   const handleClick = async () => {
     // validate OTP is set
-    if (!otp) {
+    if (!otp || !accessToken) {
       return;
     }
 

--- a/packages/ui-components/src/components/Wallet/WalletProvider.tsx
+++ b/packages/ui-components/src/components/Wallet/WalletProvider.tsx
@@ -10,11 +10,13 @@ import type {Theme} from '@mui/material/styles';
 import {useTheme} from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import Bluebird from 'bluebird';
+import {jwtDecode} from 'jwt-decode';
 import Markdown from 'markdown-to-jsx';
 import {useRouter} from 'next/router';
 import {useSnackbar} from 'notistack';
 import React, {useEffect, useState} from 'react';
 import truncateMiddle from 'truncate-middle';
+import useAsyncEffect from 'use-async-effect';
 
 import config from '@unstoppabledomains/config';
 import {makeStyles} from '@unstoppabledomains/ui-kit/styles';
@@ -258,22 +260,57 @@ export const WalletProvider: React.FC<
     onError();
   }, [errorMessage]);
 
-  useEffect(() => {
+  useAsyncEffect(async () => {
     if (
       // require completed state
       configState === WalletConfigState.Complete &&
       // require either the access token or custody secret
       (accessToken || custodySecret)
     ) {
+      // define the access token refresh timer
+      let tokenRefreshTimer: NodeJS.Timeout;
+
       // update state
       if (accessToken) {
+        // set timer to refresh the access token
+        const jwtToken = jwtDecode(accessToken);
+        if (jwtToken?.exp && jwtToken.iat) {
+          // determine the time remaining before the access token expires
+          const timeRemaining = (jwtToken.exp - jwtToken.iat) * 1000;
+          const tokenRefreshInterval = timeRemaining / 2;
+
+          // set the timer to refresh the access token
+          notifyEvent(
+            'setting timer to refresh access token',
+            'info',
+            'Wallet',
+            'Authorization',
+            {
+              meta: {
+                expiresInMs: timeRemaining,
+                refreshInMs: tokenRefreshInterval,
+              },
+            },
+          );
+          tokenRefreshTimer = setTimeout(async () => {
+            await handleRefreshAccessToken();
+          }, tokenRefreshInterval);
+        }
+
+        // callback with access token
         onUpdate(DomainProfileTabType.Wallet, {accessToken});
       }
-      setIsWalletLoaded(false);
 
       // retrieve the MPC wallets on page load
-      void loadMpcWallets();
+      if (mpcWallets.length === 0) {
+        setIsWalletLoaded(false);
+        await loadMpcWallets();
+      }
+
+      // cleanup the access token refresh timer
+      return () => clearTimeout(tokenRefreshTimer);
     }
+    return;
   }, [configState, accessToken, custodySecret]);
 
   useEffect(() => {
@@ -778,6 +815,24 @@ export const WalletProvider: React.FC<
       await handleLogout();
     } finally {
       setIsWalletLoaded(true);
+    }
+  };
+
+  const handleRefreshAccessToken = async () => {
+    try {
+      notifyEvent('refreshing access token', 'info', 'Wallet', 'Authorization');
+      const newAccessToken = await getAccessToken(true);
+      if (newAccessToken) {
+        setAccessToken(newAccessToken);
+      }
+    } catch (e) {
+      if (e instanceof SessionLockError) {
+        notifyEvent('session is locked', 'warning', 'Wallet', 'Authorization');
+        return;
+      }
+      notifyEvent(e, 'warning', 'Wallet', 'Authorization', {
+        msg: 'unable to retrieve access token',
+      });
     }
   };
 

--- a/packages/ui-components/src/lib/wallet/tokens.ts
+++ b/packages/ui-components/src/lib/wallet/tokens.ts
@@ -90,7 +90,8 @@ export const getSortedTokens = (
     ...(wallets || []).flatMap(wallet =>
       (wallet?.tokens || []).map(walletToken => {
         return {
-          type: 'Token' as never,
+          address: walletToken.address,
+          type: wallet.symbol === 'SOL' ? TokenType.Spl : TokenType.Erc20,
           name: walletToken.name,
           value: walletToken.value?.walletUsdAmt || 0,
           balance: walletToken.balanceAmt || 0,


### PR DESCRIPTION
If the user leaves their browser or extension window (e.g. the sidebar) open, the access token may expire and be invalid when they next attempt to perform an operation. Set a timer to fire and refresh the token before it expires on long-lived sessions.