### PR TITLE
Remove option to set custom avatar url

### DIFF
--- a/packages/ui-components/src/components/Manage/Tabs/Profile/AddAvatarPopup.tsx
+++ b/packages/ui-components/src/components/Manage/Tabs/Profile/AddAvatarPopup.tsx
@@ -156,30 +156,6 @@ export const AddAvatarPopup: React.FC<Props> = ({
           variant="outlined"
           color="inherit"
           disabled={uiDisabled}
-          onClick={handleUrlPopupOpen}
-          classes={{
-            startIcon: classes.buttonIconContainer,
-            disabled: classes.buttonDisabled,
-          }}
-          className={cx(classes.button, classes.marginButton)}
-          startIcon={
-            <AddLinkIcon color="primary" className={classes.buttonStartIcon} />
-          }
-          endIcon={
-            <KeyboardArrowRightOutlinedIcon className={classes.buttonEndIcon} />
-          }
-        >
-          <div className={classes.buttonText}>
-            {t('manage.enterAvatarUrl')}
-            <Typography variant="body2" color="textSecondary">
-              {t('manage.avatarUrlRequirements')}
-            </Typography>
-          </div>
-        </Button>
-        <Button
-          variant="outlined"
-          color="inherit"
-          disabled={uiDisabled}
           onClick={handleNftPopupOpen}
           classes={{
             startIcon: classes.buttonIconContainer,


### PR DESCRIPTION
Removes option to set custom avatar URL to prevent possible explicit content from being displayed. Images that are uploaded will be validated for safe content and hosted in our bucket. We can re enable this option once we add the ability to validate avatar URLs