### PR TITLE
Only load NFT data when token gallery is expanded

### DIFF
--- a/packages/ui-components/src/components/TokenGallery/TokenGallery.tsx
+++ b/packages/ui-components/src/components/TokenGallery/TokenGallery.tsx
@@ -88,6 +88,8 @@ export const useStyles = makeStyles()((theme: Theme) => ({
   },
 }));
 
+const CAROUSEL_MAX_COUNT = 5;
+
 const TokenGallery: React.FC<TokenGalleryProps> = ({
   domain,
   enabled,
@@ -147,7 +149,7 @@ const TokenGallery: React.FC<TokenGalleryProps> = ({
   // recursively load remaining NFT gallery data pages in the background
   // so they are available to the user later
   useEffect(() => {
-    if (!enabled || !expanded) {
+    if (!enabled || (!expanded && nfts && nfts.length >= CAROUSEL_MAX_COUNT)) {
       return;
     }
 
@@ -287,7 +289,7 @@ const TokenGallery: React.FC<TokenGalleryProps> = ({
         <NFTGalleryCarousel
           domain={domain}
           address={ownerAddress}
-          maxNftCount={5}
+          maxNftCount={CAROUSEL_MAX_COUNT}
           nfts={
             nfts
               ? nfts.filter(nft => nft.public && nft.verified).length < 15

--- a/packages/ui-components/src/components/TokenGallery/TokenGallery.tsx
+++ b/packages/ui-components/src/components/TokenGallery/TokenGallery.tsx
@@ -147,7 +147,7 @@ const TokenGallery: React.FC<TokenGalleryProps> = ({
   // recursively load remaining NFT gallery data pages in the background
   // so they are available to the user later
   useEffect(() => {
-    if (!enabled) {
+    if (!enabled || !expanded) {
       return;
     }
 


### PR DESCRIPTION
Currently, the token gallery starts pre-loading NFT data as soon as the page is finished loading. Update the page to only start loading once the gallery is expanded.