### PR TITLE
Fix page load problems on Firefox browser

### DIFF
--- a/packages/ui-components/src/components/Wallet/SecurityCenterModal.tsx
+++ b/packages/ui-components/src/components/Wallet/SecurityCenterModal.tsx
@@ -30,6 +30,10 @@ import type {
   RecoveryStatusResponse,
   TransactionLockStatusResponse,
 } from '../../lib/types/fireBlocks';
+import {
+  hasChromePermission,
+  isChromeExtension,
+} from '../../lib/wallet/chromeRuntime';
 import Modal from '../Modal';
 import ChangePasswordModal from './ChangePasswordModal';
 import RecoverySetupModal from './RecoverySetupModal';
@@ -121,9 +125,7 @@ const SecurityCenterModal: React.FC<Props> = ({accessToken}) => {
           getTwoFactorStatus(accessToken),
           getRecoveryKitStatus(accessToken),
           getTransactionLockStatus(accessToken),
-          chrome.permissions
-            ? chrome.permissions.contains({permissions: ['tabs']})
-            : undefined,
+          hasChromePermission('tabs'),
         ]);
         setIsLockEnabled(pinStatus);
         setIsMfaEnabled(mfaStatus);
@@ -136,7 +138,7 @@ const SecurityCenterModal: React.FC<Props> = ({accessToken}) => {
             ? txLockStatus.validUntil
             : undefined,
         );
-        setIsAppConnectionEnabled(!!tabsPermission);
+        setIsAppConnectionEnabled(tabsPermission);
       } finally {
         setIsLoaded(true);
       }
@@ -411,7 +413,7 @@ const SecurityCenterModal: React.FC<Props> = ({accessToken}) => {
           </Typography>
         </Box>
         <Box>
-          {chrome.permissions && (
+          {isChromeExtension() && (
             <WalletPreference
               title={t('extension.appConnections')}
               description={t('extension.appConnectionsDescription')}

--- a/packages/ui-components/src/components/Wallet/WalletProvider.tsx
+++ b/packages/ui-components/src/components/Wallet/WalletProvider.tsx
@@ -280,8 +280,7 @@ export const WalletProvider: React.FC<
           const timeRemaining = (jwtToken.exp - jwtToken.iat) * 1000;
           const tokenRefreshInterval = timeRemaining / 2;
 
-          // set the timer to refresh the access token
-          if (chrome?.alarms) {
+          try {
             // use chrome alarms if available
             notifyEvent(
               'setting alarm to refresh access token',
@@ -307,7 +306,7 @@ export const WalletProvider: React.FC<
                 }
               },
             );
-          } else {
+          } catch (e) {
             // use react timeout if chrome alarms are not available
             notifyEvent(
               'setting timer to refresh access token',

--- a/packages/ui-components/src/components/Wallet/WalletProvider.tsx
+++ b/packages/ui-components/src/components/Wallet/WalletProvider.tsx
@@ -55,6 +55,7 @@ import {notifyEvent} from '../../lib/error';
 import {sleep} from '../../lib/sleep';
 import type {TokenRefreshResponse} from '../../lib/types/fireBlocks';
 import type {SerializedIdentityResponse} from '../../lib/types/identity';
+import {hasChromePermission} from '../../lib/wallet/chromeRuntime';
 import {isValidWalletPasswordFormat} from '../../lib/wallet/password';
 import {
   getBootstrapState,
@@ -280,7 +281,8 @@ export const WalletProvider: React.FC<
           const timeRemaining = (jwtToken.exp - jwtToken.iat) * 1000;
           const tokenRefreshInterval = timeRemaining / 2;
 
-          try {
+          // set a timer depending on runtime environment
+          if (await hasChromePermission('alarms')) {
             // use chrome alarms if available
             notifyEvent(
               'setting alarm to refresh access token',
@@ -306,7 +308,7 @@ export const WalletProvider: React.FC<
                 }
               },
             );
-          } catch (e) {
+          } else {
             // use react timeout if chrome alarms are not available
             notifyEvent(
               'setting timer to refresh access token',

--- a/packages/ui-components/src/lib/wallet/buySellCrypto.ts
+++ b/packages/ui-components/src/lib/wallet/buySellCrypto.ts
@@ -2,6 +2,7 @@ import {stringify} from 'querystring';
 
 import config from '@unstoppabledomains/config';
 
+import {getBlockchainDisplaySymbol} from '../../components/Manage/common/verification/types';
 import {notifyEvent} from '../error';
 import type {TokenEntry} from '../types';
 
@@ -20,7 +21,7 @@ export const openBuySellPopup = async (asset: TokenEntry) => {
   const queryParams = stringify({
     blockchain: asset.name.toLowerCase(),
     address: asset.walletAddress,
-    token: asset.symbol,
+    token: getBlockchainDisplaySymbol(asset.ticker),
     utm_source: 'ud_me',
   });
   const url = `${config.UNSTOPPABLE_WEBSITE_URL}/fiat-ramps/popup?${queryParams}`;

--- a/packages/ui-components/src/lib/wallet/chromeRuntime.ts
+++ b/packages/ui-components/src/lib/wallet/chromeRuntime.ts
@@ -1,5 +1,5 @@
 export const hasChromePermission = async (
-  permission: string,
+  permission: 'tabs' | 'alarms',
 ): Promise<boolean> => {
   try {
     return await chrome.permissions.contains({permissions: [permission]});

--- a/packages/ui-components/src/lib/wallet/chromeRuntime.ts
+++ b/packages/ui-components/src/lib/wallet/chromeRuntime.ts
@@ -1,0 +1,20 @@
+export const hasChromePermission = async (
+  permission: string,
+): Promise<boolean> => {
+  try {
+    return await chrome.permissions.contains({permissions: [permission]});
+  } catch (e) {
+    // ignore
+  }
+  return false;
+};
+
+export const isChromeExtension = (): boolean => {
+  try {
+    const manifest = chrome.runtime.getManifest();
+    return manifest.manifest_version === 3;
+  } catch (e) {
+    // ignore
+  }
+  return false;
+};


### PR DESCRIPTION
On Firefox, any runtime reference to `chrome?.*` results in an exception. This is not the behavior on chrome based browsers, even though the object is still not defined on a browser runtime there either. Update error handling and usage to account for this difference.