### PR TITLE
Use wallet k/v storage for swap preferences

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unstoppabledomains/ui-components",
-  "version": "0.0.53-browser-extension.19",
+  "version": "0.0.53-browser-extension.20",
   "private": true,
   "description": "An open and reusable suite of Unstoppable Domains management components",
   "keywords": [

--- a/packages/ui-components/src/actions/walletStorageActions.ts
+++ b/packages/ui-components/src/actions/walletStorageActions.ts
@@ -2,17 +2,25 @@ import config from '@unstoppabledomains/config';
 
 import {fetchApi} from '../lib/fetchApi';
 import type {WalletStorageData} from '../lib/types/walletStorage';
+import {getAccountId} from './fireBlocksActions';
 
 const WALLET_KEY_NAME = 'general-preferences';
 
 export const clearWalletStorageData = async (
-  accountId: string,
   accessToken: string,
+  accountId?: string,
 ) => {
   try {
+    // retrieve account ID if empty
+    const normalizedAccountId =
+      accountId ?? (await getAccountId(accessToken, true));
+    if (!normalizedAccountId) {
+      return undefined;
+    }
+
     // remove data from storage
     const response = await fetchApi<WalletStorageData>(
-      `/user/${accountId}/wallet/storage/${WALLET_KEY_NAME}`,
+      `/user/${normalizedAccountId}/wallet/storage/${WALLET_KEY_NAME}`,
       {
         host: config.PROFILE.HOST_URL,
         method: 'DELETE',
@@ -33,8 +41,8 @@ export const clearWalletStorageData = async (
 };
 
 export const getWalletStorageData = async (
-  accountId: string,
   accessToken: string,
+  accountId?: string,
   forceRefresh = false,
 ): Promise<WalletStorageData | undefined> => {
   try {
@@ -44,9 +52,16 @@ export const getWalletStorageData = async (
       return JSON.parse(data);
     }
 
+    // retrieve account ID if empty
+    const normalizedAccountId =
+      accountId ?? (await getAccountId(accessToken, true));
+    if (!normalizedAccountId) {
+      return undefined;
+    }
+
     // retrieve new data if not available in session storage
     const response = await fetchApi<WalletStorageData>(
-      `/user/${accountId}/wallet/storage/${WALLET_KEY_NAME}`,
+      `/user/${normalizedAccountId}/wallet/storage/${WALLET_KEY_NAME}`,
       {
         host: config.PROFILE.HOST_URL,
         method: 'GET',
@@ -71,12 +86,20 @@ export const getWalletStorageData = async (
 
 export const setWalletStorageData = async (
   data: Record<string, string>,
-  accountId: string,
   accessToken: string,
+  accountId?: string,
 ) => {
   try {
+    // retrieve account ID if empty
+    const normalizedAccountId =
+      accountId ?? (await getAccountId(accessToken, true));
+    if (!normalizedAccountId) {
+      return undefined;
+    }
+
+    // set the wallet storage data
     const response = await fetchApi<WalletStorageData>(
-      `/user/${accountId}/wallet/storage/${WALLET_KEY_NAME}`,
+      `/user/${normalizedAccountId}/wallet/storage/${WALLET_KEY_NAME}`,
       {
         host: config.PROFILE.HOST_URL,
         method: 'POST',

--- a/packages/ui-components/src/actions/walletStorageActions.ts
+++ b/packages/ui-components/src/actions/walletStorageActions.ts
@@ -1,0 +1,98 @@
+import config from '@unstoppabledomains/config';
+
+import {fetchApi} from '../lib/fetchApi';
+import type {WalletStorageData} from '../lib/types/walletStorage';
+
+const WALLET_KEY_NAME = 'general-preferences';
+
+export const clearWalletStorageData = async (
+  accountId: string,
+  accessToken: string,
+) => {
+  try {
+    // remove data from storage
+    const response = await fetchApi<WalletStorageData>(
+      `/user/${accountId}/wallet/storage/${WALLET_KEY_NAME}`,
+      {
+        host: config.PROFILE.HOST_URL,
+        method: 'DELETE',
+        headers: {
+          'Content-type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+      },
+    );
+
+    // update cache and return
+    if (response) {
+      sessionStorage.removeItem(WALLET_KEY_NAME);
+      return response;
+    }
+  } catch (e) {}
+  return undefined;
+};
+
+export const getWalletStorageData = async (
+  accountId: string,
+  accessToken: string,
+  forceRefresh = false,
+) => {
+  try {
+    // retrieve from session storage if available
+    const data = sessionStorage.getItem(WALLET_KEY_NAME);
+    if (data && !forceRefresh) {
+      return JSON.parse(data);
+    }
+
+    // retrieve new data if not available in session storage
+    const response = await fetchApi<WalletStorageData>(
+      `/user/${accountId}/wallet/storage/${WALLET_KEY_NAME}`,
+      {
+        host: config.PROFILE.HOST_URL,
+        method: 'GET',
+        headers: {
+          'Content-type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+      },
+    );
+
+    // update cache and return
+    sessionStorage.setItem(WALLET_KEY_NAME, JSON.stringify(response || {}));
+    if (response) {
+      return response;
+    }
+  } catch (e) {
+    // set empty object in session storage
+    sessionStorage.setItem(WALLET_KEY_NAME, JSON.stringify({}));
+  }
+  return undefined;
+};
+
+export const setWalletStorageData = async (
+  data: Record<string, string>,
+  accountId: string,
+  accessToken: string,
+) => {
+  try {
+    const response = await fetchApi<WalletStorageData>(
+      `/user/${accountId}/wallet/storage/${WALLET_KEY_NAME}`,
+      {
+        host: config.PROFILE.HOST_URL,
+        method: 'POST',
+        headers: {
+          'Content-type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify(JSON.stringify(data)),
+      },
+    );
+
+    // update cache and return
+    if (response) {
+      sessionStorage.setItem(WALLET_KEY_NAME, JSON.stringify(response));
+      return response;
+    }
+  } catch (e) {}
+  return undefined;
+};

--- a/packages/ui-components/src/actions/walletStorageActions.ts
+++ b/packages/ui-components/src/actions/walletStorageActions.ts
@@ -1,43 +1,48 @@
+import {Mutex} from 'async-mutex';
+
 import config from '@unstoppabledomains/config';
 
 import {fetchApi} from '../lib/fetchApi';
 import type {WalletStorageData} from '../lib/types/walletStorage';
 import {getAccountId} from './fireBlocksActions';
 
+// wallet storage control variables
 const WALLET_KEY_NAME = 'general-preferences';
+const walletStorageMutex = new Mutex();
 
 export const clearWalletStorageData = async (
   accessToken: string,
   accountId?: string,
-) => {
-  try {
-    // retrieve account ID if empty
-    const normalizedAccountId =
-      accountId ?? (await getAccountId(accessToken, true));
-    if (!normalizedAccountId) {
-      return undefined;
-    }
+): Promise<WalletStorageData | undefined> => {
+  return await walletStorageMutex.runExclusive(async () => {
+    try {
+      // retrieve account ID if empty
+      const normalizedAccountId =
+        accountId ?? (await getAccountId(accessToken, true));
+      if (!normalizedAccountId) {
+        return undefined;
+      }
 
-    // remove data from storage
-    const response = await fetchApi<WalletStorageData>(
-      `/user/${normalizedAccountId}/wallet/storage/${WALLET_KEY_NAME}`,
-      {
-        host: config.PROFILE.HOST_URL,
-        method: 'DELETE',
-        headers: {
-          'Content-type': 'application/json',
-          Authorization: `Bearer ${accessToken}`,
+      // remove data from storage
+      const response = await fetchApi<WalletStorageData>(
+        `/user/${normalizedAccountId}/wallet/storage/${WALLET_KEY_NAME}`,
+        {
+          host: config.PROFILE.HOST_URL,
+          method: 'DELETE',
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
         },
-      },
-    );
+      );
 
-    // update cache and return
-    if (response) {
-      sessionStorage.removeItem(WALLET_KEY_NAME);
-      return response;
-    }
-  } catch (e) {}
-  return undefined;
+      // update cache and return
+      if (response) {
+        sessionStorage.removeItem(WALLET_KEY_NAME);
+        return response;
+      }
+    } catch (e) {}
+    return undefined;
+  });
 };
 
 export const getWalletStorageData = async (
@@ -45,77 +50,79 @@ export const getWalletStorageData = async (
   accountId?: string,
   forceRefresh = false,
 ): Promise<WalletStorageData | undefined> => {
-  try {
-    // retrieve from session storage if available
-    const data = sessionStorage.getItem(WALLET_KEY_NAME);
-    if (data && !forceRefresh) {
-      return JSON.parse(data);
-    }
+  return await walletStorageMutex.runExclusive(async () => {
+    try {
+      // retrieve from session storage if available
+      const data = sessionStorage.getItem(WALLET_KEY_NAME);
+      if (data && !forceRefresh) {
+        return JSON.parse(data);
+      }
 
-    // retrieve account ID if empty
-    const normalizedAccountId =
-      accountId ?? (await getAccountId(accessToken, true));
-    if (!normalizedAccountId) {
-      return undefined;
-    }
+      // retrieve account ID if empty
+      const normalizedAccountId =
+        accountId ?? (await getAccountId(accessToken, true));
+      if (!normalizedAccountId) {
+        return undefined;
+      }
 
-    // retrieve new data if not available in session storage
-    const response = await fetchApi<WalletStorageData>(
-      `/user/${normalizedAccountId}/wallet/storage/${WALLET_KEY_NAME}`,
-      {
-        host: config.PROFILE.HOST_URL,
-        method: 'GET',
-        headers: {
-          'Content-type': 'application/json',
-          Authorization: `Bearer ${accessToken}`,
+      // retrieve new data if not available in session storage
+      const response = await fetchApi<WalletStorageData>(
+        `/user/${normalizedAccountId}/wallet/storage/${WALLET_KEY_NAME}`,
+        {
+          host: config.PROFILE.HOST_URL,
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
         },
-      },
-    );
+      );
 
-    // update cache and return
-    sessionStorage.setItem(WALLET_KEY_NAME, JSON.stringify(response || {}));
-    if (response) {
-      return response;
+      // update cache and return
+      sessionStorage.setItem(WALLET_KEY_NAME, JSON.stringify(response || {}));
+      if (response) {
+        return response;
+      }
+    } catch (e) {
+      // set empty object in session storage
+      sessionStorage.setItem(WALLET_KEY_NAME, JSON.stringify({}));
     }
-  } catch (e) {
-    // set empty object in session storage
-    sessionStorage.setItem(WALLET_KEY_NAME, JSON.stringify({}));
-  }
-  return undefined;
+    return undefined;
+  });
 };
 
 export const setWalletStorageData = async (
   data: Record<string, string>,
   accessToken: string,
   accountId?: string,
-) => {
-  try {
-    // retrieve account ID if empty
-    const normalizedAccountId =
-      accountId ?? (await getAccountId(accessToken, true));
-    if (!normalizedAccountId) {
-      return undefined;
-    }
+): Promise<WalletStorageData | undefined> => {
+  return await walletStorageMutex.runExclusive(async () => {
+    try {
+      // retrieve account ID if empty
+      const normalizedAccountId =
+        accountId ?? (await getAccountId(accessToken, true));
+      if (!normalizedAccountId) {
+        return undefined;
+      }
 
-    // set the wallet storage data
-    const response = await fetchApi<WalletStorageData>(
-      `/user/${normalizedAccountId}/wallet/storage/${WALLET_KEY_NAME}`,
-      {
-        host: config.PROFILE.HOST_URL,
-        method: 'POST',
-        headers: {
-          'Content-type': 'application/json',
-          Authorization: `Bearer ${accessToken}`,
+      // set the wallet storage data
+      const response = await fetchApi<WalletStorageData>(
+        `/user/${normalizedAccountId}/wallet/storage/${WALLET_KEY_NAME}`,
+        {
+          host: config.PROFILE.HOST_URL,
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+          body: JSON.stringify(data),
         },
-        body: JSON.stringify(JSON.stringify(data)),
-      },
-    );
+      );
 
-    // update cache and return
-    if (response) {
-      sessionStorage.setItem(WALLET_KEY_NAME, JSON.stringify(response));
-      return response;
-    }
-  } catch (e) {}
-  return undefined;
+      // update cache and return
+      if (response) {
+        sessionStorage.setItem(WALLET_KEY_NAME, JSON.stringify(response));
+        return response;
+      }
+    } catch (e) {}
+    return undefined;
+  });
 };

--- a/packages/ui-components/src/actions/walletStorageActions.ts
+++ b/packages/ui-components/src/actions/walletStorageActions.ts
@@ -36,7 +36,7 @@ export const getWalletStorageData = async (
   accountId: string,
   accessToken: string,
   forceRefresh = false,
-) => {
+): Promise<WalletStorageData | undefined> => {
   try {
     // retrieve from session storage if available
     const data = sessionStorage.getItem(WALLET_KEY_NAME);

--- a/packages/ui-components/src/components/Chat/storage.ts
+++ b/packages/ui-components/src/components/Chat/storage.ts
@@ -78,8 +78,8 @@ export class localStorageWrapper {
   ): Promise<string | null> {
     return isChromeStorageType(opts.type) && isChromeStorageSupported(opts.type)
       ? await localStorageWrapper.getChromeStorage(k, opts.type)
-      : opts.type === 'wallet' && opts.accessToken && opts.accountId
-      ? WalletStorageProvider.getItem(k, opts.accountId, opts.accessToken)
+      : opts.type === 'wallet' && opts.accessToken
+      ? WalletStorageProvider.getItem(k, opts.accessToken, opts.accountId)
       : localStorage.getItem(k);
   }
 
@@ -91,12 +91,12 @@ export class localStorageWrapper {
     if (isChromeStorageType(opts.type) && isChromeStorageSupported(opts.type)) {
       await chrome.storage[opts.type].set({[k]: v});
       return;
-    } else if (opts.type === 'wallet' && opts.accessToken && opts.accountId) {
+    } else if (opts.type === 'wallet' && opts.accessToken) {
       await WalletStorageProvider.setItem(
         k,
         v,
-        opts.accountId,
         opts.accessToken,
+        opts.accountId,
       );
       return;
     }
@@ -110,11 +110,11 @@ export class localStorageWrapper {
     if (isChromeStorageType(opts.type) && isChromeStorageSupported(opts.type)) {
       await chrome.storage[opts.type].remove(k);
       return;
-    } else if (opts.type === 'wallet' && opts.accessToken && opts.accountId) {
+    } else if (opts.type === 'wallet' && opts.accessToken) {
       await WalletStorageProvider.removeItem(
         k,
-        opts.accountId,
         opts.accessToken,
+        opts.accountId,
       );
       return;
     }
@@ -127,8 +127,8 @@ export class localStorageWrapper {
     if (isChromeStorageType(opts.type) && isChromeStorageSupported(opts.type)) {
       await chrome.storage[opts.type].clear();
       return;
-    } else if (opts.type === 'wallet' && opts.accessToken && opts.accountId) {
-      await WalletStorageProvider.clear(opts.accountId, opts.accessToken);
+    } else if (opts.type === 'wallet' && opts.accessToken) {
+      await WalletStorageProvider.clear(opts.accessToken, opts.accountId);
       return;
     }
     localStorage.clear();

--- a/packages/ui-components/src/components/DropDownMenu.tsx
+++ b/packages/ui-components/src/components/DropDownMenu.tsx
@@ -148,7 +148,8 @@ const DropDownMenu: React.FC<Props> = ({
 
   const handleLogout = async () => {
     setLoggingOut(prev => !prev);
-    await localStorageWrapper.clear();
+    await localStorageWrapper.clear({type: 'local'});
+    await localStorageWrapper.clear({type: 'session'});
     sessionStorage.clear();
     if (onLogout) {
       onLogout();

--- a/packages/ui-components/src/components/Wallet/Client.tsx
+++ b/packages/ui-components/src/components/Wallet/Client.tsx
@@ -263,7 +263,7 @@ export const Client: React.FC<ClientProps> = ({
     const [lockStatus] = await Promise.all([
       getTransactionLockStatus(accessToken),
       accountId
-        ? getWalletStorageData(accountId, accessToken, true)
+        ? getWalletStorageData(accessToken, accountId, true)
         : undefined,
     ]);
 

--- a/packages/ui-components/src/components/Wallet/Client.tsx
+++ b/packages/ui-components/src/components/Wallet/Client.tsx
@@ -316,6 +316,11 @@ export const Client: React.FC<ClientProps> = ({
     // prioritize security health check
     const isHealthCheckCleared = await localStorageWrapper.getItem(
       DomainProfileKeys.BannerHealthCheck,
+      {
+        type: 'wallet',
+        accessToken,
+        accountId: getAccountIdFromBootstrapState(clientState),
+      },
     );
     if (!isHealthCheckCleared && onSecurityCenterClicked) {
       setBanner(
@@ -512,6 +517,11 @@ export const Client: React.FC<ClientProps> = ({
     await localStorageWrapper.setItem(
       DomainProfileKeys.BannerHealthCheck,
       String(Date.now()),
+      {
+        type: 'wallet',
+        accessToken,
+        accountId: getAccountIdFromBootstrapState(clientState),
+      },
     );
     if (enabled && onSecurityCenterClicked) {
       onSecurityCenterClicked();

--- a/packages/ui-components/src/components/Wallet/Client.tsx
+++ b/packages/ui-components/src/components/Wallet/Client.tsx
@@ -259,13 +259,12 @@ export const Client: React.FC<ClientProps> = ({
     }
 
     // retrieve API calls concurrently
+    const accountId = getAccountIdFromBootstrapState(clientState);
     const [lockStatus] = await Promise.all([
       getTransactionLockStatus(accessToken),
-      getWalletStorageData(
-        getAccountIdFromBootstrapState(clientState),
-        accessToken,
-        true,
-      ),
+      accountId
+        ? getWalletStorageData(accountId, accessToken, true)
+        : undefined,
     ]);
 
     // set wallet lock status

--- a/packages/ui-components/src/components/Wallet/DomainWalletTransactions.tsx
+++ b/packages/ui-components/src/components/Wallet/DomainWalletTransactions.tsx
@@ -215,6 +215,11 @@ export const DomainWalletTransactions: React.FC<
 
   // load previously known transactions from local state
   useAsyncEffect(async () => {
+    // only load transactions if the wallet is owned
+    if (!isOwner) {
+      return;
+    }
+
     // retrieve previously known transactions from local state
     const cachedTxns = await localStorageWrapper.getItem(
       DomainProfileKeys.WalletTransactions,
@@ -222,7 +227,7 @@ export const DomainWalletTransactions: React.FC<
     if (cachedTxns) {
       setTxns(JSON.parse(cachedTxns));
     }
-  }, []);
+  }, [isOwner]);
 
   // update transactions dynamically
   useAsyncEffect(async () => {

--- a/packages/ui-components/src/components/Wallet/SecurityCenterModal.tsx
+++ b/packages/ui-components/src/components/Wallet/SecurityCenterModal.tsx
@@ -24,8 +24,14 @@ import {
   getTransactionLockStatus,
 } from '../../actions/fireBlocksActions';
 import {getTwoFactorStatus} from '../../actions/walletMfaActions';
-import {useWeb3Context} from '../../hooks';
-import {disablePin, isPinEnabled, useTranslationContext} from '../../lib';
+import {useFireblocksState, useWeb3Context} from '../../hooks';
+import {
+  disablePin,
+  getAccountIdFromBootstrapState,
+  getBootstrapState,
+  isPinEnabled,
+  useTranslationContext,
+} from '../../lib';
 import type {
   RecoveryStatusResponse,
   TransactionLockStatusResponse,
@@ -91,6 +97,8 @@ const SecurityCenterModal: React.FC<Props> = ({accessToken}) => {
   const {classes, cx} = useStyles();
   const [t] = useTranslationContext();
   const {setTxLockStatus} = useWeb3Context();
+  const [state] = useFireblocksState();
+  const clientState = getBootstrapState(state);
   const theme = useTheme();
   const {data: featureFlags} = useFeatureFlags(false);
   const [recoveryKitStatus, setRecoveryKitStatus] =
@@ -161,7 +169,10 @@ const SecurityCenterModal: React.FC<Props> = ({accessToken}) => {
 
   const handleLockClicked = async () => {
     if (isLockEnabled) {
-      await disablePin();
+      await disablePin({
+        accessToken,
+        accountId: getAccountIdFromBootstrapState(clientState),
+      });
       setIsLockEnabled(false);
     } else {
       setIsLockModalOpen(true);

--- a/packages/ui-components/src/components/Wallet/SelectAsset.tsx
+++ b/packages/ui-components/src/components/Wallet/SelectAsset.tsx
@@ -12,12 +12,19 @@ import useAsyncEffect from 'use-async-effect';
 import type {ImmutableArray} from '@unstoppabledomains/config/build/src/env/types';
 import {makeStyles} from '@unstoppabledomains/ui-kit/styles';
 
+import {useFireblocksState, useWeb3Context} from '../../hooks';
 import type {
   DomainBannerType,
   SerializedWalletBalance,
   TokenEntry,
 } from '../../lib';
-import {DomainProfileKeys, TokenType, useTranslationContext} from '../../lib';
+import {
+  DomainProfileKeys,
+  TokenType,
+  getAccountIdFromBootstrapState,
+  getBootstrapState,
+  useTranslationContext,
+} from '../../lib';
 import {getAllTokens} from '../../lib/wallet/evm/token';
 import {filterWallets} from '../../lib/wallet/filter';
 import {localStorageWrapper} from '../Chat';
@@ -106,6 +113,9 @@ export const SelectAsset: React.FC<Props> = ({
 }) => {
   const {classes} = useStyles();
   const [t] = useTranslationContext();
+  const {accessToken} = useWeb3Context();
+  const [state] = useFireblocksState();
+  const clientState = getBootstrapState(state);
   const [showBanner, setShowBanner] = useState<boolean>(false);
 
   const wallets = filterWallets(initialWallets, supportedAssetList);
@@ -143,6 +153,11 @@ export const SelectAsset: React.FC<Props> = ({
     // check if banner should be shown
     const bannerState = await localStorageWrapper.getItem(
       `${DomainProfileKeys.Banner}-${bannerType}`,
+      {
+        type: 'wallet',
+        accessToken,
+        accountId: getAccountIdFromBootstrapState(clientState),
+      },
     );
     setShowBanner(!bannerState);
   }, [bannerType]);
@@ -152,6 +167,11 @@ export const SelectAsset: React.FC<Props> = ({
     await localStorageWrapper.setItem(
       `${DomainProfileKeys.Banner}-${bannerType}`,
       String(Date.now()),
+      {
+        type: 'wallet',
+        accessToken,
+        accountId: getAccountIdFromBootstrapState(clientState),
+      },
     );
   };
 

--- a/packages/ui-components/src/components/Wallet/SetupPinModal.tsx
+++ b/packages/ui-components/src/components/Wallet/SetupPinModal.tsx
@@ -9,7 +9,14 @@ import React, {useState} from 'react';
 import config from '@unstoppabledomains/config';
 import {makeStyles} from '@unstoppabledomains/ui-kit/styles';
 
-import {createPIN, unlock, useTranslationContext} from '../../lib';
+import {useFireblocksState} from '../../hooks';
+import {
+  createPIN,
+  getAccountIdFromBootstrapState,
+  getBootstrapState,
+  unlock,
+  useTranslationContext,
+} from '../../lib';
 import ManageInput from '../Manage/common/ManageInput';
 import {OperationStatus} from './OperationStatus';
 
@@ -46,6 +53,8 @@ type Props = {
 const SetupPinModal: React.FC<Props> = ({accessToken, onComplete, onClose}) => {
   const {classes} = useStyles();
   const [t] = useTranslationContext();
+  const [state] = useFireblocksState();
+  const clientState = getBootstrapState(state);
   const [password, setPassword] = useState<string>();
   const [isSuccess, setIsSuccess] = useState<boolean>();
   const [isSaving, setIsSaving] = useState(false);
@@ -77,11 +86,17 @@ const SetupPinModal: React.FC<Props> = ({accessToken, onComplete, onClose}) => {
       return;
     }
 
+    // retrieve account ID
+    const accountId = getAccountIdFromBootstrapState(clientState);
+    if (!accountId) {
+      return;
+    }
+
     // set saving state
     setIsSaving(true);
 
     // enable the PIN with provided value
-    await createPIN(password, accessToken);
+    await createPIN(password, accountId, accessToken);
     await unlock(password, config.WALLETS.DEFAULT_PIN_TIMEOUT_MS);
 
     // set success state

--- a/packages/ui-components/src/components/Wallet/Swap.tsx
+++ b/packages/ui-components/src/components/Wallet/Swap.tsx
@@ -39,6 +39,7 @@ import type {SerializedWalletBalance, TokenEntry} from '../../lib';
 import {
   DomainProfileKeys,
   TokenType,
+  getAccountIdFromBootstrapState,
   getBootstrapState,
   notifyEvent,
   useTranslationContext,
@@ -224,6 +225,7 @@ const Swap: React.FC<Props> = ({
 
   // fireblocks state
   const [state] = useFireblocksState();
+  const clientState = getBootstrapState(state);
   const fireblocksMessageSigner = useFireblocksMessageSigner();
 
   // operation state
@@ -693,14 +695,25 @@ const Swap: React.FC<Props> = ({
 
   useAsyncEffect(async () => {
     // determine swap intro visibility
+    const accountId = getAccountIdFromBootstrapState(clientState);
     const swapIntroState = await localStorageWrapper.getItem(
       DomainProfileKeys.BannerSwapIntro,
+      {
+        type: 'wallet',
+        accessToken,
+        accountId,
+      },
     );
     setShowSwapIntro(swapIntroState === null);
 
     // determine swap mode
     const swapMode = await localStorageWrapper.getItem(
       DomainProfileKeys.WalletSwapMode,
+      {
+        type: 'wallet',
+        accessToken,
+        accountId,
+      },
     );
     if (swapMode) {
       setSourceTokenAmountMode(swapMode as SwapMode);
@@ -807,6 +820,11 @@ const Swap: React.FC<Props> = ({
     await localStorageWrapper.setItem(
       DomainProfileKeys.WalletSwapMode,
       newMode,
+      {
+        type: 'wallet',
+        accessToken,
+        accountId: getAccountIdFromBootstrapState(clientState),
+      },
     );
   };
 
@@ -815,6 +833,11 @@ const Swap: React.FC<Props> = ({
     await localStorageWrapper.setItem(
       DomainProfileKeys.BannerSwapIntro,
       String(Date.now()),
+      {
+        type: 'wallet',
+        accessToken,
+        accountId: getAccountIdFromBootstrapState(clientState),
+      },
     );
   };
 
@@ -1098,7 +1121,6 @@ const Swap: React.FC<Props> = ({
     try {
       // retrieve and validate fireblocks state
       setIsSwapping(true);
-      const clientState = getBootstrapState(state);
       if (!clientState) {
         throw new Error('invalid wallet client state');
       }

--- a/packages/ui-components/src/components/Wallet/Swap.tsx
+++ b/packages/ui-components/src/components/Wallet/Swap.tsx
@@ -704,7 +704,7 @@ const Swap: React.FC<Props> = ({
         accountId,
       },
     );
-    setShowSwapIntro(swapIntroState === null);
+    setShowSwapIntro(!swapIntroState);
 
     // determine swap mode
     const swapMode = await localStorageWrapper.getItem(

--- a/packages/ui-components/src/components/Wallet/TokenDetail.tsx
+++ b/packages/ui-components/src/components/Wallet/TokenDetail.tsx
@@ -79,7 +79,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
     marginBottom: theme.spacing(1),
   },
   refreshIcon: {
-    color: theme.palette.text.secondary,
+    color: theme.palette.wallet.text.secondary,
     width: '20px',
     height: '20px',
   },

--- a/packages/ui-components/src/hooks/useChromeStorage.ts
+++ b/packages/ui-components/src/hooks/useChromeStorage.ts
@@ -2,9 +2,9 @@ import {useEffect, useState} from 'react';
 
 import {notifyEvent} from '../lib/error';
 
-type chromeStorageType = 'local' | 'session' | 'sync';
+export type ChromeStorageType = 'local' | 'session' | 'sync';
 
-export const isChromeStorageSupported = (type: chromeStorageType) => {
+export const isChromeStorageSupported = (type: ChromeStorageType) => {
   try {
     if (chrome?.storage?.[type]) {
       return true;
@@ -15,10 +15,16 @@ export const isChromeStorageSupported = (type: chromeStorageType) => {
   return false;
 };
 
+export const isChromeStorageType = (
+  type: string,
+): type is ChromeStorageType => {
+  return ['local', 'session', 'sync'].includes(type);
+};
+
 const useChromeStorage = <T>(
   key: string,
   initialValue: T,
-  type: chromeStorageType = 'session',
+  type: ChromeStorageType = 'session',
 ): [T, (state: T) => void] => {
   const [chromeStorageState, setChromeStorageState] = useState<T>(initialValue);
 

--- a/packages/ui-components/src/hooks/useWeb3Context.tsx
+++ b/packages/ui-components/src/hooks/useWeb3Context.tsx
@@ -3,7 +3,6 @@ import useAsyncEffect from 'use-async-effect';
 
 import config from '@unstoppabledomains/config';
 
-import {getAccounts} from '../actions/fireBlocksActions';
 import {getWalletStorageData} from '../actions/walletStorageActions';
 import {localStorageWrapper} from '../components';
 import {
@@ -119,19 +118,14 @@ const useWeb3Context = () => {
     }
 
     try {
-      // retrieve encrypted PIN from remote configuration
-      const accounts = await getAccounts(accessToken);
-      const accountId =
-        accounts?.items && accounts.items.length > 0
-          ? accounts.items[0].id
-          : undefined;
-      const encryptedPin = accountId
-        ? await localStorageWrapper.getItem(DomainProfileKeys.EncryptedPIN, {
-            type: 'wallet',
-            accessToken,
-            accountId,
-          })
-        : undefined;
+      // retrieve the encrypted PIN from remote wallet configuration
+      const encryptedPin = await localStorageWrapper.getItem(
+        DomainProfileKeys.EncryptedPIN,
+        {
+          type: 'wallet',
+          accessToken,
+        },
+      );
 
       // synchronize the remote and local encrypted PIN configurations
       if (encryptedPin) {
@@ -140,9 +134,12 @@ const useWeb3Context = () => {
           DomainProfileKeys.EncryptedPIN,
           encryptedPin,
         );
-      } else if (accountId) {
+      } else {
+        // TODO: this code can be removed in a future release once migration
+        // has had an opportunity to complete
+
         // only sync local configuration if remote configuration is empty
-        const walletConfig = await getWalletStorageData(accountId, accessToken);
+        const walletConfig = await getWalletStorageData(accessToken);
 
         // set the remote encrypted PIN to the one set locally
         if (
@@ -159,7 +156,6 @@ const useWeb3Context = () => {
               {
                 type: 'wallet',
                 accessToken,
-                accountId,
               },
             );
           }

--- a/packages/ui-components/src/hooks/useWeb3Context.tsx
+++ b/packages/ui-components/src/hooks/useWeb3Context.tsx
@@ -3,7 +3,17 @@ import useAsyncEffect from 'use-async-effect';
 
 import config from '@unstoppabledomains/config';
 
-import {isLocked, isPinEnabled, lock, notifyEvent, unlock} from '../lib';
+import {getAccounts} from '../actions/fireBlocksActions';
+import {getWalletStorageData} from '../actions/walletStorageActions';
+import {localStorageWrapper} from '../components';
+import {
+  DomainProfileKeys,
+  isLocked,
+  isPinEnabled,
+  lock,
+  notifyEvent,
+  unlock,
+} from '../lib';
 import {getPinFromToken} from '../lib/wallet/pin/store';
 import {Web3Context} from '../providers/Web3ContextProvider';
 
@@ -67,6 +77,9 @@ const useWeb3Context = () => {
       setShowPinCta(false);
       clearTimeout(lockScreenTimeout);
 
+      // synchronize the encrypted PIN
+      await synchronizeEncryptedPin();
+
       // check if session lock is enabled
       if (await isPinEnabled()) {
         // bump the lock state to the future due to usage
@@ -98,6 +111,64 @@ const useWeb3Context = () => {
     };
     void checkPinState();
   }, [accessToken, persistentKeyState, sessionKeyState, showPinCta]);
+
+  const synchronizeEncryptedPin = async () => {
+    // access token is required
+    if (!accessToken) {
+      return;
+    }
+
+    try {
+      // retrieve encrypted PIN from remote configuration
+      const accounts = await getAccounts(accessToken);
+      const accountId =
+        accounts?.items && accounts.items.length > 0
+          ? accounts.items[0].id
+          : undefined;
+      const encryptedPin = accountId
+        ? await localStorageWrapper.getItem(DomainProfileKeys.EncryptedPIN, {
+            type: 'wallet',
+            accessToken,
+            accountId,
+          })
+        : undefined;
+
+      // synchronize the remote and local encrypted PIN configurations
+      if (encryptedPin) {
+        // set the local encrypted PIN to the one set remotely
+        await localStorageWrapper.setItem(
+          DomainProfileKeys.EncryptedPIN,
+          encryptedPin,
+        );
+      } else if (accountId) {
+        // only sync local configuration if remote configuration is empty
+        const walletConfig = await getWalletStorageData(accountId, accessToken);
+
+        // set the remote encrypted PIN to the one set locally
+        if (
+          !walletConfig?.data ||
+          Object.keys(JSON.parse(walletConfig.data)).length === 0
+        ) {
+          const localEncryptedPin = await localStorageWrapper.getItem(
+            DomainProfileKeys.EncryptedPIN,
+          );
+          if (localEncryptedPin) {
+            await localStorageWrapper.setItem(
+              DomainProfileKeys.EncryptedPIN,
+              localEncryptedPin,
+              {
+                type: 'wallet',
+                accessToken,
+                accountId,
+              },
+            );
+          }
+        }
+      }
+    } catch (e) {
+      notifyEvent(e, 'warning', 'Wallet', 'Configuration');
+    }
+  };
 
   const handleLockScreen = async () => {
     if (!persistentKeyState) {

--- a/packages/ui-components/src/lib/types/walletStorage.ts
+++ b/packages/ui-components/src/lib/types/walletStorage.ts
@@ -1,0 +1,7 @@
+export interface WalletStorageData {
+  createdDate: Date;
+  updatedDate: Date;
+  key: string;
+  data: string;
+  schema?: string;
+}

--- a/packages/ui-components/src/lib/wallet/pin/key.test.ts
+++ b/packages/ui-components/src/lib/wallet/pin/key.test.ts
@@ -2,6 +2,7 @@ import * as storage from '../../../components/Chat/storage';
 import {createPIN} from './key';
 import {getKeypairFromPin, getKeypairFromToken, getPublicKey} from './store';
 
+const mockAccountId = '1234567890';
 const mockToken =
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwczovL2FwaS51bnN0b3BwYWJsZWRvbWFpbnMuY29tL2NsYWltcy90b2tlbi1wdXJwb3NlIjoiUkVGUkVTSCIsImh0dHBzOi8vYXBpLnVuc3RvcHBhYmxlZG9tYWlucy5jb20vY2xhaW1zL2FjY291bnQiOiJXQUxMRVRfVVNFUiIsImh0dHBzOi8vYXBpLnVuc3RvcHBhYmxlZG9tYWlucy5jb20vY2xhaW1zL2NvbnRleHQiOiJkY0ZmS081SmZtNC9tWmxCekJLZHpmankvODRlS214cndBaFNMYUNYQjByV1BuNTVhZDY0c2VnL1U1eGVURkhtYU1WMVRTa2RudTBaWGZmTkxNcy9ZZm9LQTZUb0ZiY2QzWUZRbmxxUWt4T2N6U3pNMWllTjVNVkIrbGVkdXI5S3lmdmk0ZUZ5NVl1MFcwVXozaGRoY2pWb3NCUWF4TmM5SFF0VWxBaHVObDgyVmJQbDBBV2VBMzY5R0ZDVnVWY3B6SjU2bEc3cHpUMlh1VUJ5bDVjRU1VZFhQS1FnYjZja2s5ekV0WHFnNWN6S2lxYVBocFdvenBGM3pjK1YyMFVMNW1IbjhjQmN4WENzNWZ6Um85cWhZSUU5SGorSG9INFIrbHZqejZIeUppKzlQR3hBcy9ObFkvYmNJbnV2MERwV0VqN0tkSjc1Uy9hRks5R3g4dDVTODlxS3F2eHk0VERLZVJHWnh1OUc4Wmc1TDdWWVJDUGNqTTMyWVZxQ3grRnJUL0JBM3ppLzhpbjJTSUsya2duTkFxbHFCbENtemVLTnBGTTZwbEFWNndKazFBUkxLOHgwNGhCTTZPTWlBMDJnMVpYTjQyRWl6UVpWbk5DdURadllnbExJMExHTnZUcnpmMU1UazVVWW92MkM1RkhpQktzcGlZUFY4OCt6em1yeHZFSkZnTEkzd1BWdmNrZkpQUHZrT2ltRjhJTkU1VDdDR3FjM0ZydVZrV1FLN0xta2pGbUxaOEErZklQVCtyRFlObEpmaG13Nnd6N1A3Q0lBazQ1SFd5U1BZUGJtUm5jYzVSUjR0d3JnNndSM3Vic0x4UUJhK2ZNMjJ0dUYrZXpWaTNvd0E4SEUvdTJTMzg2UHdjdGhjWXRJY1RqODVLVjg1SzM5RmhuWEJlVVQ2cEE0eThYTTRyS2RTTnlKUGxQanBiTURrSC84bEQraDY5a3dZVXZrSTN6SU5pZUpYbXhBZW1vQUFrdWFkN1Era1FiSEVqc0diUXhrZ3FmVkVlRDkzWUwvTGJjTXd3VGJoVWtXaU1rWE55VWFDVGx2aFZYK1MvaDRTZ3JLdkpkZmNxVFhxRVJ0SU0yeTFzaVF3ZEVjaTBONVBQc2lmM3k4Q1hTOG9DL3hLVUkwNUY4MWF4dGdPRm01Q2Via0p1cHZreUp5MFBBWGgrcE9LTGtOYmJMTEtxVlp5UGl4bUJGVnVyNThIWFpmQTJlNFR1MFZyL2dnL2g4Q3NyeC9sOWxYOTVnSTUra1c2WXRWK0xkaTVBSkpUVmlmTHRHdGpEa3dFZlVsV2VRaDhCVTgweUF3UXpNcXZ6dmFSdWVUOUd5SytoeTJyOVVQd2hKZnhVSVhqeTBWZGpjRytzSXNoODNpNFF5MFpZeTM5TlEwUGw3dlJ1dERXMk9OM05NU0RuN1FacFhvWkZkeHBEVHNFb3RzNDUyTzFhcEw1SEtoc0dWK1hoSVpRUFpER24wZFJOc0FmQ09IUnE4ZTdqTk44WEo0OE9yVFNKb1R2S3ZYNTY0K0lGZlE0WW81aWZCMDlHMU43OXlubTBBV1haL1hoa1J3YUR4dVVSdElBdkRVSGMyVkFJV2RVemR5RDNRYWxjZDhwY2hlUGNSSjl0aE95RkxoVnRHWXZJN1I3ekQrNDhJZm12bDM2Zm5UME9oREF2WCt1ZW4xQjAyamE2T3VzQjJQSUVZb0FDVy9QUW9RSC9hc3FSZDk1SjRKTGpkMUpJZEZhMkx5d1I4S3djbzZuTE5YMkJocTZSdW9ucEpSREg1eFVBM01mbDBPVFpLeVJTeTZQRE5COXlsR25ENktKWmg2UW5pdnFjZWkwRVMrV3Q2d1g1eTBjU0RvMmlZbHZpY1RGWDdiSmxRMUpBPT0iLCJpYXQiOjE3Mzc3NTc2MDgsImV4cCI6MTc2OTI5MzYwOCwiYXVkIjoiMzFjOTMzOWYtZWMyYy00NDIxLWJhYzAtMDRkYzRlYTRjZDdiIiwiaXNzIjoiaHR0cHM6Ly9hcGkudW5zdG9wcGFibGVkb21haW5zLmNvbSJ9.9yGyDwAlgiAPwK56bkQPXvqspNf0NdNFed_BNmg3SJw';
 
@@ -21,27 +22,27 @@ describe('PIN key management', () => {
   });
 
   it('should create and store a new public key', async () => {
-    const publicKey = await createPIN('1234', mockToken);
+    const publicKey = await createPIN('1234', mockAccountId, mockToken);
     const retrievedKey = await getPublicKey();
     expect(publicKey).toEqual(retrievedKey?.toBase58());
   });
 
   it('should retrieve a private key with correct PIN', async () => {
-    const publicKey = await createPIN('1234', mockToken);
+    const publicKey = await createPIN('1234', mockAccountId, mockToken);
     const retrievedKey = await getKeypairFromPin('1234');
     expect(publicKey).toEqual(retrievedKey?.publicKey.toBase58());
     expect(retrievedKey.secretKey).toBeDefined();
   });
 
   it('should retrieve a private key with valid JWT', async () => {
-    const publicKey = await createPIN('1234', mockToken);
+    const publicKey = await createPIN('1234', mockAccountId, mockToken);
     const retrievedKey = await getKeypairFromToken(mockToken);
     expect(publicKey).toEqual(retrievedKey?.publicKey.toBase58());
     expect(retrievedKey.secretKey).toBeDefined();
   });
 
   it('should retrieve the same secret using PIN or JWT', async () => {
-    const publicKey = await createPIN('1234', mockToken);
+    const publicKey = await createPIN('1234', mockAccountId, mockToken);
     const retrievedKeyPin = await getKeypairFromPin('1234');
     const retrievedKeyToken = await getKeypairFromToken(mockToken);
     expect(publicKey).toEqual(retrievedKeyPin?.publicKey.toBase58());
@@ -49,7 +50,7 @@ describe('PIN key management', () => {
   });
 
   it('should not retrieve a private key with incorrect correct PIN', async () => {
-    const publicKey = await createPIN('1234', mockToken);
+    const publicKey = await createPIN('1234', mockAccountId, mockToken);
     expect(publicKey).toBeDefined();
     await expect(getKeypairFromPin('BAD_PIN')).rejects.toThrow('invalid PIN');
   });

--- a/packages/ui-components/src/lib/wallet/pin/key.ts
+++ b/packages/ui-components/src/lib/wallet/pin/key.ts
@@ -9,6 +9,7 @@ import {SessionLockError} from './types';
 
 export const createPIN = async (
   pin: string,
+  accountId: string,
   accessToken: string,
 ): Promise<string> => {
   // create a new public key pair
@@ -23,11 +24,14 @@ export const createPIN = async (
 
   // store the public key and encrypted private key
   const publicKey = pinKeypair.publicKey.toBase58();
-  await saveEncryptedPin({
-    encryptedPrivateKey,
-    encryptedPin,
-    publicKey,
-  });
+  await saveEncryptedPin(
+    {
+      encryptedPrivateKey,
+      encryptedPin,
+      publicKey,
+    },
+    {accessToken, accountId},
+  );
   return publicKey;
 };
 

--- a/packages/ui-components/src/lib/wallet/pin/locker.test.ts
+++ b/packages/ui-components/src/lib/wallet/pin/locker.test.ts
@@ -3,6 +3,7 @@ import {createPIN} from './key';
 import {isPinEnabled, isUnlocked, unlock} from './locker';
 import {saveLockStatus} from './store';
 
+const mockAccountId = '1234567890';
 const mockToken =
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJodHRwczovL2FwaS51bnN0b3BwYWJsZWRvbWFpbnMuY29tL2NsYWltcy90b2tlbi1wdXJwb3NlIjoiUkVGUkVTSCIsImh0dHBzOi8vYXBpLnVuc3RvcHBhYmxlZG9tYWlucy5jb20vY2xhaW1zL2FjY291bnQiOiJXQUxMRVRfVVNFUiIsImh0dHBzOi8vYXBpLnVuc3RvcHBhYmxlZG9tYWlucy5jb20vY2xhaW1zL2NvbnRleHQiOiJkY0ZmS081SmZtNC9tWmxCekJLZHpmankvODRlS214cndBaFNMYUNYQjByV1BuNTVhZDY0c2VnL1U1eGVURkhtYU1WMVRTa2RudTBaWGZmTkxNcy9ZZm9LQTZUb0ZiY2QzWUZRbmxxUWt4T2N6U3pNMWllTjVNVkIrbGVkdXI5S3lmdmk0ZUZ5NVl1MFcwVXozaGRoY2pWb3NCUWF4TmM5SFF0VWxBaHVObDgyVmJQbDBBV2VBMzY5R0ZDVnVWY3B6SjU2bEc3cHpUMlh1VUJ5bDVjRU1VZFhQS1FnYjZja2s5ekV0WHFnNWN6S2lxYVBocFdvenBGM3pjK1YyMFVMNW1IbjhjQmN4WENzNWZ6Um85cWhZSUU5SGorSG9INFIrbHZqejZIeUppKzlQR3hBcy9ObFkvYmNJbnV2MERwV0VqN0tkSjc1Uy9hRks5R3g4dDVTODlxS3F2eHk0VERLZVJHWnh1OUc4Wmc1TDdWWVJDUGNqTTMyWVZxQ3grRnJUL0JBM3ppLzhpbjJTSUsya2duTkFxbHFCbENtemVLTnBGTTZwbEFWNndKazFBUkxLOHgwNGhCTTZPTWlBMDJnMVpYTjQyRWl6UVpWbk5DdURadllnbExJMExHTnZUcnpmMU1UazVVWW92MkM1RkhpQktzcGlZUFY4OCt6em1yeHZFSkZnTEkzd1BWdmNrZkpQUHZrT2ltRjhJTkU1VDdDR3FjM0ZydVZrV1FLN0xta2pGbUxaOEErZklQVCtyRFlObEpmaG13Nnd6N1A3Q0lBazQ1SFd5U1BZUGJtUm5jYzVSUjR0d3JnNndSM3Vic0x4UUJhK2ZNMjJ0dUYrZXpWaTNvd0E4SEUvdTJTMzg2UHdjdGhjWXRJY1RqODVLVjg1SzM5RmhuWEJlVVQ2cEE0eThYTTRyS2RTTnlKUGxQanBiTURrSC84bEQraDY5a3dZVXZrSTN6SU5pZUpYbXhBZW1vQUFrdWFkN1Era1FiSEVqc0diUXhrZ3FmVkVlRDkzWUwvTGJjTXd3VGJoVWtXaU1rWE55VWFDVGx2aFZYK1MvaDRTZ3JLdkpkZmNxVFhxRVJ0SU0yeTFzaVF3ZEVjaTBONVBQc2lmM3k4Q1hTOG9DL3hLVUkwNUY4MWF4dGdPRm01Q2Via0p1cHZreUp5MFBBWGgrcE9LTGtOYmJMTEtxVlp5UGl4bUJGVnVyNThIWFpmQTJlNFR1MFZyL2dnL2g4Q3NyeC9sOWxYOTVnSTUra1c2WXRWK0xkaTVBSkpUVmlmTHRHdGpEa3dFZlVsV2VRaDhCVTgweUF3UXpNcXZ6dmFSdWVUOUd5SytoeTJyOVVQd2hKZnhVSVhqeTBWZGpjRytzSXNoODNpNFF5MFpZeTM5TlEwUGw3dlJ1dERXMk9OM05NU0RuN1FacFhvWkZkeHBEVHNFb3RzNDUyTzFhcEw1SEtoc0dWK1hoSVpRUFpER24wZFJOc0FmQ09IUnE4ZTdqTk44WEo0OE9yVFNKb1R2S3ZYNTY0K0lGZlE0WW81aWZCMDlHMU43OXlubTBBV1haL1hoa1J3YUR4dVVSdElBdkRVSGMyVkFJV2RVemR5RDNRYWxjZDhwY2hlUGNSSjl0aE95RkxoVnRHWXZJN1I3ekQrNDhJZm12bDM2Zm5UME9oREF2WCt1ZW4xQjAyamE2T3VzQjJQSUVZb0FDVy9QUW9RSC9hc3FSZDk1SjRKTGpkMUpJZEZhMkx5d1I4S3djbzZuTE5YMkJocTZSdW9ucEpSREg1eFVBM01mbDBPVFpLeVJTeTZQRE5COXlsR25ENktKWmg2UW5pdnFjZWkwRVMrV3Q2d1g1eTBjU0RvMmlZbHZpY1RGWDdiSmxRMUpBPT0iLCJpYXQiOjE3Mzc3NTc2MDgsImV4cCI6MTc2OTI5MzYwOCwiYXVkIjoiMzFjOTMzOWYtZWMyYy00NDIxLWJhYzAtMDRkYzRlYTRjZDdiIiwiaXNzIjoiaHR0cHM6Ly9hcGkudW5zdG9wcGFibGVkb21haW5zLmNvbSJ9.9yGyDwAlgiAPwK56bkQPXvqspNf0NdNFed_BNmg3SJw';
 
@@ -22,7 +23,7 @@ describe('PIN locker', () => {
   });
 
   it('should return true if PIN is enabled', async () => {
-    await createPIN('1234', mockToken);
+    await createPIN('1234', mockAccountId, mockToken);
     expect(await isPinEnabled()).toBeTruthy();
   });
 
@@ -31,26 +32,26 @@ describe('PIN locker', () => {
   });
 
   it('should be unlocked if timestamp is valid', async () => {
-    await createPIN('1234', mockToken);
+    await createPIN('1234', mockAccountId, mockToken);
     const expirationTime = await unlock('1234', 10000);
     expect(expirationTime).toBeGreaterThan(Date.now());
     expect(await isUnlocked()).toBeTruthy();
   });
 
   it('should fail to unlock with incorrect PIN', async () => {
-    await createPIN('1234', mockToken);
+    await createPIN('1234', mockAccountId, mockToken);
     await expect(unlock('BAD_PIN', 10000)).rejects.toThrow('invalid PIN');
   });
 
   it('should be locked if timestamp is expired', async () => {
-    await createPIN('1234', mockToken);
+    await createPIN('1234', mockAccountId, mockToken);
     const expirationTime = await unlock('1234', -10000);
     expect(expirationTime).toBeLessThan(Date.now());
     expect(await isUnlocked()).toBeFalsy();
   });
 
   it('should be unlocked if proof is invalid', async () => {
-    await createPIN('1234', mockToken);
+    await createPIN('1234', mockAccountId, mockToken);
     await saveLockStatus({
       timestamp: Date.now() + 10000,
       proof:

--- a/packages/ui-components/src/lib/wallet/pin/locker.ts
+++ b/packages/ui-components/src/lib/wallet/pin/locker.ts
@@ -18,8 +18,11 @@ import {
 } from './store';
 import {SessionLockError} from './types';
 
-export const disablePin = async () => {
-  await Promise.all([removeEncryptedPin(), removeLockStatus()]);
+export const disablePin = async (opts?: {
+  accessToken?: string;
+  accountId?: string;
+}) => {
+  await Promise.all([removeEncryptedPin(opts), removeLockStatus()]);
 };
 
 export const isLocked = async () => {

--- a/packages/ui-components/src/lib/wallet/pin/store.ts
+++ b/packages/ui-components/src/lib/wallet/pin/store.ts
@@ -73,20 +73,52 @@ export const getPublicKey = async (): Promise<PublicKey | undefined> => {
   return new PublicKey(encryptedPin.publicKey);
 };
 
-export const removeEncryptedPin = async () => {
+export const removeEncryptedPin = async (opts?: {
+  accessToken?: string;
+  accountId?: string;
+}) => {
+  // remove the PIN from local storage
   await localStorageWrapper.removeItem(DomainProfileKeys.EncryptedPIN);
+
+  // if requested, also remove the configuration from wallet storage
+  if (opts?.accessToken && opts?.accountId) {
+    await localStorageWrapper.removeItem(DomainProfileKeys.EncryptedPIN, {
+      type: 'wallet',
+      accessToken: opts.accessToken,
+      accountId: opts.accountId,
+    });
+  }
 };
 
 export const removeLockStatus = async () => {
   await localStorageWrapper.removeItem(DomainProfileKeys.LockStatus);
 };
 
-export const saveEncryptedPin = async (data: EncryptedPin) => {
-  // store the public key and encrypted private key
+export const saveEncryptedPin = async (
+  data: EncryptedPin,
+  opts?: {
+    accessToken?: string;
+    accountId?: string;
+  },
+) => {
+  // store the public key and encrypted private key to local storage
   await localStorageWrapper.setItem(
     DomainProfileKeys.EncryptedPIN,
     JSON.stringify(data),
   );
+
+  // if requested, also store the configuration to wallet storage
+  if (opts?.accessToken && opts?.accountId) {
+    await localStorageWrapper.setItem(
+      DomainProfileKeys.EncryptedPIN,
+      JSON.stringify(data),
+      {
+        type: 'wallet',
+        accessToken: opts.accessToken,
+        accountId: opts.accountId,
+      },
+    );
+  }
 };
 
 export const saveLockStatus = async (data: LockStatus) => {

--- a/packages/ui-components/src/lib/wallet/storage/provider.ts
+++ b/packages/ui-components/src/lib/wallet/storage/provider.ts
@@ -7,13 +7,13 @@ import {
 export class WalletStorageProvider {
   static async getItem(
     k: string,
-    accountId: string,
     accessToken: string,
+    accountId?: string,
   ): Promise<string | null> {
     // retrieve wallet storage data
     const walletPreferences = await getWalletStorageData(
-      accountId,
       accessToken,
+      accountId,
     );
     if (!walletPreferences?.data) {
       return null;
@@ -27,13 +27,13 @@ export class WalletStorageProvider {
   static async setItem(
     k: string,
     v: string,
-    accountId: string,
     accessToken: string,
+    accountId?: string,
   ): Promise<void> {
     // retrieve wallet storage data
     const walletPreferences = await getWalletStorageData(
-      accountId,
       accessToken,
+      accountId,
     );
 
     // return the value for requested key if present
@@ -45,18 +45,18 @@ export class WalletStorageProvider {
     data[k] = v;
 
     // update wallet storage data
-    await setWalletStorageData(data, accountId, accessToken);
+    await setWalletStorageData(data, accessToken, accountId);
   }
 
   static async removeItem(
     k: string,
-    accountId: string,
     accessToken: string,
+    accountId?: string,
   ): Promise<void> {
     // retrieve wallet storage data
     const walletPreferences = await getWalletStorageData(
-      accountId,
       accessToken,
+      accountId,
     );
     if (!walletPreferences?.data) {
       return;
@@ -67,10 +67,10 @@ export class WalletStorageProvider {
     delete data[k];
 
     // update wallet storage data
-    await setWalletStorageData(data, accountId, accessToken);
+    await setWalletStorageData(data, accessToken, accountId);
   }
 
-  static async clear(accountId: string, accessToken: string): Promise<void> {
-    await clearWalletStorageData(accountId, accessToken);
+  static async clear(accessToken: string, accountId?: string): Promise<void> {
+    await clearWalletStorageData(accessToken, accountId);
   }
 }

--- a/packages/ui-components/src/lib/wallet/storage/provider.ts
+++ b/packages/ui-components/src/lib/wallet/storage/provider.ts
@@ -1,0 +1,76 @@
+import {
+  clearWalletStorageData,
+  getWalletStorageData,
+  setWalletStorageData,
+} from '../../../actions/walletStorageActions';
+
+export class WalletStorageProvider {
+  static async getItem(
+    k: string,
+    accountId: string,
+    accessToken: string,
+  ): Promise<string | null> {
+    // retrieve wallet storage data
+    const walletPreferences = await getWalletStorageData(
+      accountId,
+      accessToken,
+    );
+    if (!walletPreferences?.data) {
+      return null;
+    }
+
+    // return the value for requested key if present
+    const data: Record<string, string> = JSON.parse(walletPreferences.data);
+    return data[k];
+  }
+
+  static async setItem(
+    k: string,
+    v: string,
+    accountId: string,
+    accessToken: string,
+  ): Promise<void> {
+    // retrieve wallet storage data
+    const walletPreferences = await getWalletStorageData(
+      accountId,
+      accessToken,
+    );
+
+    // return the value for requested key if present
+    const data: Record<string, string> = walletPreferences?.data
+      ? JSON.parse(walletPreferences.data)
+      : {};
+
+    // update the value for requested key
+    data[k] = v;
+
+    // update wallet storage data
+    await setWalletStorageData(data, accountId, accessToken);
+  }
+
+  static async removeItem(
+    k: string,
+    accountId: string,
+    accessToken: string,
+  ): Promise<void> {
+    // retrieve wallet storage data
+    const walletPreferences = await getWalletStorageData(
+      accountId,
+      accessToken,
+    );
+    if (!walletPreferences?.data) {
+      return;
+    }
+
+    // remove the value for requested key
+    const data: Record<string, string> = JSON.parse(walletPreferences.data);
+    delete data[k];
+
+    // update wallet storage data
+    await setWalletStorageData(data, accountId, accessToken);
+  }
+
+  static async clear(accountId: string, accessToken: string): Promise<void> {
+    await clearWalletStorageData(accountId, accessToken);
+  }
+}

--- a/packages/ui-components/src/lib/wallet/storage/state.ts
+++ b/packages/ui-components/src/lib/wallet/storage/state.ts
@@ -10,12 +10,12 @@ import {
 
 export const getAccountIdFromBootstrapState = (
   state?: BootstrapState,
-): string => {
+): string | undefined => {
   if (!state?.assets || state.assets.length === 0) {
-    throw new Error('No assets found in bootstrap state');
+    return undefined;
   }
   if (!state.assets[0].accountId) {
-    throw new Error('No account ID found in bootstrap state');
+    return undefined;
   }
   return state.assets[0].accountId;
 };

--- a/packages/ui-components/src/lib/wallet/storage/state.ts
+++ b/packages/ui-components/src/lib/wallet/storage/state.ts
@@ -8,6 +8,18 @@ import {
   BootstrapStatePrefix,
 } from '../../types/fireBlocks';
 
+export const getAccountIdFromBootstrapState = (
+  state?: BootstrapState,
+): string => {
+  if (!state?.assets || state.assets.length === 0) {
+    throw new Error('No assets found in bootstrap state');
+  }
+  if (!state.assets[0].accountId) {
+    throw new Error('No account ID found in bootstrap state');
+  }
+  return state.assets[0].accountId;
+};
+
 export const getBootstrapState = (
   state: Record<string, Record<string, string>>,
 ): BootstrapState | undefined => {

--- a/server/pages/wallet/index.page.tsx
+++ b/server/pages/wallet/index.page.tsx
@@ -63,7 +63,8 @@ const WalletPage = () => {
       return;
     }
     if (Object.keys(walletState).length > 0) {
-      void localStorageWrapper.clear();
+      void localStorageWrapper.clear({type: 'local'});
+      void localStorageWrapper.clear({type: 'session'});
       sessionStorage.clear();
       window.location.reload();
       return;


### PR DESCRIPTION
Move to wallet based configuration target for certain configuration values that were previously stored locally. This allows configuration items to persist across devices.

- Banner acknowledgments
- Session timeout / PIN settings