### PR TITLE
Validate token decimal precision when creating a Solana transaction

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unstoppabledomains/ui-components",
-  "version": "0.0.53-browser-extension.29",
+  "version": "0.0.53-browser-extension.30",
   "private": true,
   "description": "An open and reusable suite of Unstoppable Domains management components",
   "keywords": [

--- a/packages/ui-components/src/lib/wallet/solana/transaction.ts
+++ b/packages/ui-components/src/lib/wallet/solana/transaction.ts
@@ -68,7 +68,7 @@ export const createNativeTransferTx = async (
       SystemProgram.transfer({
         fromPubkey: fromWalletSigner.publicKey,
         toPubkey,
-        lamports: amount * LAMPORTS_PER_SOL,
+        lamports: Math.floor(amount * LAMPORTS_PER_SOL),
       }),
     ),
     fromAddress,
@@ -133,7 +133,7 @@ export const createSplTransferTx = async (
         fromTokenAccount.address,
         toTokenAccount.address,
         fromWalletSigner.publicKey,
-        amount * Math.pow(10, tokenDecimals),
+        Math.floor(amount * Math.pow(10, tokenDecimals)),
       ),
     ),
     fromAddress,


### PR DESCRIPTION
The Solana token SDK expects decimal validation prior to being called. Adding these checks to prevent errors when transferring token amounts with many decimal places.