### PR TITLE
Enable NFT transfers within wallet

### DIFF
--- a/packages/ui-components/package.json
+++ b/packages/ui-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unstoppabledomains/ui-components",
-  "version": "0.0.53-browser-extension.33",
+  "version": "0.0.53-browser-extension.34",
   "private": true,
   "description": "An open and reusable suite of Unstoppable Domains management components",
   "keywords": [

--- a/packages/ui-components/src/components/TokenGallery/NftCard.tsx
+++ b/packages/ui-components/src/components/TokenGallery/NftCard.tsx
@@ -83,6 +83,7 @@ interface Props {
   placeholder?: boolean;
   compact?: boolean;
   onClick?: (selected: Nft) => void;
+  onTransferNft?: (nft: Nft) => void;
 }
 
 const NftCard = ({
@@ -92,6 +93,7 @@ const NftCard = ({
   compact,
   placeholder,
   onClick,
+  onTransferNft,
 }: Props) => {
   const [t] = useTranslationContext();
   const videoRef = useRef(null);
@@ -248,6 +250,13 @@ const NftCard = ({
 
   const handleSetPfpClicked = () => {
     setPfpModalOpen(true);
+  };
+
+  const handleTransferNft = (selectedNft: Nft) => {
+    if (onTransferNft) {
+      onTransferNft(selectedNft);
+      handleClose();
+    }
   };
 
   const handleToggleCollectionVisibility = (v: boolean) => {
@@ -430,6 +439,7 @@ const NftCard = ({
         {open && (
           <NftModal
             handleClose={handleClose}
+            handleTransferNft={onTransferNft ? handleTransferNft : undefined}
             open={open}
             nft={nft}
             domain={domain}

--- a/packages/ui-components/src/components/TokenGallery/NftModal.tsx
+++ b/packages/ui-components/src/components/TokenGallery/NftModal.tsx
@@ -1,6 +1,7 @@
 import Close from '@mui/icons-material/Close';
 import OpenInNew from '@mui/icons-material/OpenInNew';
 import PortraitOutlinedIcon from '@mui/icons-material/PortraitOutlined';
+import SendIcon from '@mui/icons-material/Send';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Grid from '@mui/material/Grid';
@@ -216,6 +217,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
 
 export interface NftModalProps {
   handleClose: () => void;
+  handleTransferNft?: () => void;
   domain?: string;
   address?: string;
   open: boolean;
@@ -227,6 +229,7 @@ const NftModal: React.FC<NftModalProps> = ({
   address,
   open,
   handleClose,
+  handleTransferNft,
   nft,
 }: NftModalProps) => {
   const {classes, cx} = useStyles();
@@ -399,6 +402,18 @@ const NftModal: React.FC<NftModalProps> = ({
                   </Button>
                 </Box>
               )}
+              {handleTransferNft && (
+                <Box mt={2}>
+                  <Button
+                    variant="contained"
+                    startIcon={<SendIcon />}
+                    onClick={handleTransferNft}
+                    size="small"
+                  >
+                    {t('common.send')}
+                  </Button>
+                </Box>
+              )}
               {avatarClicked && domain && address && (
                 <SelectNftPopup
                   domain={domain}
@@ -420,7 +435,7 @@ const NftModal: React.FC<NftModalProps> = ({
             )}
             {(nft.acquiredDate ||
               nft.rarity?.rank ||
-              nft.saleDetails ||
+              nft.saleDetails?.primary?.cost ||
               nft.floorPrice) && (
               <section className={classes.details}>
                 <Typography variant="subtitle2" className={classes.sectionName}>

--- a/packages/ui-components/src/components/TokenGallery/NftModal.tsx
+++ b/packages/ui-components/src/components/TokenGallery/NftModal.tsx
@@ -217,7 +217,7 @@ const useStyles = makeStyles()((theme: Theme) => ({
 
 export interface NftModalProps {
   handleClose: () => void;
-  handleTransferNft?: () => void;
+  handleTransferNft?: (nft: Nft) => void;
   domain?: string;
   address?: string;
   open: boolean;
@@ -407,7 +407,7 @@ const NftModal: React.FC<NftModalProps> = ({
                   <Button
                     variant="contained"
                     startIcon={<SendIcon />}
-                    onClick={handleTransferNft}
+                    onClick={() => handleTransferNft(nft)}
                     size="small"
                   >
                     {t('common.send')}

--- a/packages/ui-components/src/components/Wallet/Client.tsx
+++ b/packages/ui-components/src/components/Wallet/Client.tsx
@@ -759,6 +759,7 @@ export const Client: React.FC<ClientProps> = ({
 
   const handleTokenClicked = (token: TokenEntry) => {
     setSelectedToken(token);
+    setSelectedNft(undefined);
   };
 
   const handleNftClicked = async (collection: TokenEntry) => {
@@ -791,6 +792,7 @@ export const Client: React.FC<ClientProps> = ({
   const handleViewSwapToken = (token: TokenEntry) => {
     setSelectedToken(token);
     setIsSwap(false);
+    setSelectedNft(undefined);
   };
 
   const handleClickedChat = () => {
@@ -820,6 +822,7 @@ export const Client: React.FC<ClientProps> = ({
     setIsBuy(false);
     setIsSwap(false);
     setIsChat(false);
+    setSelectedNft(undefined);
   };
 
   const handleClickedSwap = () => {
@@ -838,6 +841,7 @@ export const Client: React.FC<ClientProps> = ({
     setIsSend(false);
     setIsReceive(false);
     setIsChat(false);
+    setSelectedNft(undefined);
   };
 
   const handleClickedBuy = () => {
@@ -846,6 +850,7 @@ export const Client: React.FC<ClientProps> = ({
     setIsReceive(false);
     setIsSwap(false);
     setIsChat(false);
+    setSelectedNft(undefined);
   };
 
   const handleClickedReceive = () => {
@@ -854,6 +859,7 @@ export const Client: React.FC<ClientProps> = ({
     setIsBuy(false);
     setIsSwap(false);
     setIsChat(false);
+    setSelectedNft(undefined);
   };
 
   const handleCancelAction = () => {
@@ -863,6 +869,9 @@ export const Client: React.FC<ClientProps> = ({
     setIsBuy(false);
     setIsSwap(false);
     setIsChat(false);
+    setSelectedNft(undefined);
+    setSelectedNftCollection(undefined);
+    setSelectedToken(undefined);
 
     // if message tab was clicked, go to home
     if (tabValue === ClientTabType.Messages) {

--- a/packages/ui-components/src/components/Wallet/Client.tsx
+++ b/packages/ui-components/src/components/Wallet/Client.tsx
@@ -300,6 +300,7 @@ export const Client: React.FC<ClientProps> = ({
   const [selectedNftCollection, setSelectedNftCollection] =
     useState<TokenEntry>();
   const [selectedNft, setSelectedNft] = useState<Nft>();
+  const [isNftModalOpen, setIsNftModalOpen] = useState(false);
   const [isNftLoading, setIsNftLoading] = useState(false);
 
   // owner address
@@ -539,6 +540,11 @@ export const Client: React.FC<ClientProps> = ({
     setTxLockStatus(status);
   };
 
+  const handleTransferNft = () => {
+    setIsNftModalOpen(false);
+    setIsSend(true);
+  };
+
   // configure a CTA to prompt the user to set their password if the wallet
   // is in custody and has a crypto balance
   const showPasswordCta = async () => {
@@ -768,11 +774,17 @@ export const Client: React.FC<ClientProps> = ({
         const nft = nftList[0];
         nft.symbol = collection.symbol;
         setSelectedNft(nft);
+        setIsNftModalOpen(true);
       }
     } else {
       // view the collection NFT list
       setSelectedNftCollection(collection);
     }
+  };
+
+  const handleCloseNftModal = () => {
+    setIsNftModalOpen(false);
+    setSelectedNft(undefined);
   };
 
   const handleViewSwapToken = (token: TokenEntry) => {
@@ -859,6 +871,7 @@ export const Client: React.FC<ClientProps> = ({
 
   const handleCancelToken = () => {
     setSelectedToken(undefined);
+    setSelectedNft(undefined);
     handleCancelAction();
   };
 
@@ -924,6 +937,7 @@ export const Client: React.FC<ClientProps> = ({
               onClickReceive={handleClickedReceive}
               wallets={wallets}
               initialSelectedToken={selectedToken}
+              initialSelectedNft={selectedNft}
             />
           </Box>
         ) : isSwap && accessToken ? (
@@ -1268,11 +1282,12 @@ export const Client: React.FC<ClientProps> = ({
           </TabContext>
         )}
       </Box>
-      {selectedNft && (
+      {selectedNft && isNftModalOpen && (
         <NftModal
-          open={true}
+          open={isNftModalOpen}
           nft={selectedNft}
-          handleClose={() => setSelectedNft(undefined)}
+          handleClose={handleCloseNftModal}
+          handleTransferNft={handleTransferNft}
         />
       )}
       {domainToManage && (

--- a/packages/ui-components/src/components/Wallet/Client.tsx
+++ b/packages/ui-components/src/components/Wallet/Client.tsx
@@ -540,7 +540,8 @@ export const Client: React.FC<ClientProps> = ({
     setTxLockStatus(status);
   };
 
-  const handleTransferNft = () => {
+  const handleTransferNft = (nft: Nft) => {
+    setSelectedNft(nft);
     setIsNftModalOpen(false);
     setIsSend(true);
   };
@@ -987,6 +988,7 @@ export const Client: React.FC<ClientProps> = ({
               accessToken={accessToken}
               collection={selectedNftCollection}
               onCancelClick={handleCancelNftCollection}
+              onTransferNft={handleTransferNft}
             />
           </Box>
         ) : (

--- a/packages/ui-components/src/components/Wallet/NftCollectionDetail.tsx
+++ b/packages/ui-components/src/components/Wallet/NftCollectionDetail.tsx
@@ -73,6 +73,7 @@ const NftCollectionDetail: React.FC<Props> = ({
       collection.walletAddress,
       collection.address,
       cursor,
+      true,
     );
     if (data?.[collection.symbol]) {
       // normalize NFT data

--- a/packages/ui-components/src/components/Wallet/NftCollectionDetail.tsx
+++ b/packages/ui-components/src/components/Wallet/NftCollectionDetail.tsx
@@ -44,9 +44,14 @@ type Props = {
   accessToken: string;
   collection: TokenEntry;
   onCancelClick: () => void;
+  onTransferNft: (nft: Nft) => void;
 };
 
-const NftCollectionDetail: React.FC<Props> = ({collection, onCancelClick}) => {
+const NftCollectionDetail: React.FC<Props> = ({
+  collection,
+  onCancelClick,
+  onTransferNft,
+}) => {
   const {classes} = useStyles();
   const [hasMore, setHasMore] = useState(false);
   const [cursor, setCursor] = useState<string>();
@@ -104,7 +109,11 @@ const NftCollectionDetail: React.FC<Props> = ({collection, onCancelClick}) => {
               ? nfts.map((nft, index) => (
                   <Grid key={`nft-${index}`} item xs={6}>
                     <Box className={classes.cardContainer}>
-                      <NftCard nft={nft} key={index} />
+                      <NftCard
+                        nft={nft}
+                        key={index}
+                        onTransferNft={onTransferNft}
+                      />
                     </Box>
                   </Grid>
                 ))

--- a/packages/ui-components/src/components/Wallet/Send.tsx
+++ b/packages/ui-components/src/components/Wallet/Send.tsx
@@ -85,6 +85,9 @@ const useStyles = makeStyles()((theme: Theme) => ({
     borderRadius: '50%',
     boxShadow: theme.shadows[6],
   },
+  assetLogoNft: {
+    borderRadius: theme.shape.borderRadius,
+  },
   sendAssetContainer: {
     display: 'flex',
     flexDirection: 'column',
@@ -230,6 +233,12 @@ const Send: React.FC<Props> = ({
         getBlockchainDisplaySymbol(nft.symbol!),
     );
     if (!wallet) {
+      return;
+    }
+
+    // validate the chain is either SOL or an EVM chain with a mint address
+    // that contains two parts, the contract address and the token ID.
+    if (nft.symbol !== 'SOL' && nft.mint.split('/').length !== 2) {
       return;
     }
 
@@ -521,7 +530,12 @@ const Send: React.FC<Props> = ({
       <Box className={classes.contentWrapper}>
         <Box className={classes.selectAssetContainer}>
           <Box className={classes.sendAssetContainer}>
-            <img src={selectedToken.imageUrl} className={classes.assetLogo} />
+            <img
+              src={selectedToken.imageUrl}
+              className={cx(classes.assetLogo, {
+                [classes.assetLogoNft]: !!initialSelectedNft,
+              })}
+            />
           </Box>
           <Box className={classes.recipientWrapper}>
             <AddressInput

--- a/packages/ui-components/src/components/Wallet/SendConfirm.tsx
+++ b/packages/ui-components/src/components/Wallet/SendConfirm.tsx
@@ -108,7 +108,9 @@ export const SendConfirm: React.FC<Props> = ({
           <Typography variant="h4" textAlign="center">
             {amount} {getBlockchainDisplaySymbol(symbol)}
           </Typography>
-          <Typography variant="body2">{amountInDollars}</Typography>
+          {amountInDollars && (
+            <Typography variant="body2">{amountInDollars}</Typography>
+          )}
           <Box className={classes.contentContainer} mt={3}>
             <Box
               display="flex"

--- a/packages/ui-components/src/hooks/useSubmitTransaction.ts
+++ b/packages/ui-components/src/hooks/useSubmitTransaction.ts
@@ -3,6 +3,7 @@ import {useEffect, useRef, useState} from 'react';
 import {
   SendCryptoStatusMessage,
   cancelPendingOperations,
+  createSolanaTokenTransfer,
   createTransactionOperation,
   createTransferOperation,
   getOperationStatus,
@@ -22,13 +23,7 @@ import {
 } from '../lib/types/fireBlocks';
 import type {AccountAsset, GetOperationResponse} from '../lib/types/fireBlocks';
 import {createErc20TransferTx} from '../lib/wallet/evm/token';
-import {
-  broadcastTx,
-  createNativeTransferTx,
-  createSplTransferTx,
-  signTransaction,
-  waitForTx,
-} from '../lib/wallet/solana/transaction';
+import {waitForTx} from '../lib/wallet/solana/transaction';
 import useDomainConfig from './useDomainConfig';
 import useFireblocksMessageSigner from './useFireblocksMessageSigner';
 import useResolverKeys from './useResolverKeys';
@@ -129,40 +124,25 @@ export const useSubmitTransaction = ({
       // handle an Solana SPL token transfer
       if (token.address && token.type === TokenType.Spl) {
         try {
-          // create the transaction that must be signed
-          setStatusMessage(SendCryptoStatusMessage.STARTING_TRANSACTION);
-          const tx = await createSplTransferTx(
+          // submit the transaction to be signed by the wallet
+          setStatusMessage(SendCryptoStatusMessage.SIGNING);
+          const txResult = await createSolanaTokenTransfer(
+            accessToken,
             token.walletAddress,
             recipientAddress,
-            token.address,
             parseFloat(amount),
-            fireblocksMessageSigner,
-            accessToken,
+            token.address,
+            otpToken,
           );
-
-          // sign and wait for the signature value
-          setStatusMessage(SendCryptoStatusMessage.SIGNING);
-          const signedTx = await signTransaction(
-            tx,
-            token.walletAddress,
-            fireblocksMessageSigner,
-            accessToken,
-            false,
-          );
-
-          // submit the transaction
-          setStatusMessage(SendCryptoStatusMessage.SUBMITTING_TRANSACTION);
-          const txHash = await broadcastTx(
-            signedTx,
-            token.walletAddress,
-            accessToken,
-          );
+          if (!txResult?.hash) {
+            throw new Error('Error submitting transaction');
+          }
 
           // wait for transaction confirmation
           setStatusMessage(SendCryptoStatusMessage.WAITING_FOR_TRANSACTION);
           setShowSuccessAnimation(true);
-          setTransactionId(txHash);
-          await waitForTx(txHash, token.walletAddress, accessToken);
+          setTransactionId(txResult.hash);
+          await waitForTx(txResult.hash, token.walletAddress, accessToken);
 
           // operation is complete
           setStatusMessage(SendCryptoStatusMessage.TRANSACTION_COMPLETED);
@@ -195,35 +175,25 @@ export const useSubmitTransaction = ({
       // handle Solana native transfer
       if (asset.blockchainAsset.blockchain.id.toLowerCase() === 'solana') {
         try {
-          // create the transaction that must be signed
-          setStatusMessage(SendCryptoStatusMessage.STARTING_TRANSACTION);
-          const fromAddress = asset.address;
-          const tx = await createNativeTransferTx(
-            fromAddress,
+          // submit the transaction to be signed by the wallet
+          setStatusMessage(SendCryptoStatusMessage.SIGNING);
+          const txResult = await createSolanaTokenTransfer(
+            accessToken,
+            token.walletAddress,
             recipientAddress,
             parseFloat(amount),
-            accessToken,
+            undefined,
+            otpToken,
           );
-
-          // sign and wait for the signature value
-          setStatusMessage(SendCryptoStatusMessage.SIGNING);
-          const signedTx = await signTransaction(
-            tx,
-            fromAddress,
-            fireblocksMessageSigner,
-            accessToken,
-            false,
-          );
-
-          // submit the transaction
-          setStatusMessage(SendCryptoStatusMessage.SUBMITTING_TRANSACTION);
-          const txHash = await broadcastTx(signedTx, fromAddress, accessToken);
+          if (!txResult?.hash) {
+            throw new Error('Error submitting transaction');
+          }
 
           // wait for transaction confirmation
           setStatusMessage(SendCryptoStatusMessage.WAITING_FOR_TRANSACTION);
           setShowSuccessAnimation(true);
-          setTransactionId(txHash);
-          await waitForTx(txHash, fromAddress, accessToken);
+          setTransactionId(txResult.hash);
+          await waitForTx(txResult.hash, token.walletAddress, accessToken);
 
           // operation is complete
           setStatusMessage(SendCryptoStatusMessage.TRANSACTION_COMPLETED);

--- a/packages/ui-components/src/lib/types/domain.ts
+++ b/packages/ui-components/src/lib/types/domain.ts
@@ -550,6 +550,7 @@ export const TldCache = new Keyv<string[]>({
 export enum TokenType {
   Native = 'native',
   Erc20 = 'erc20',
+  Erc721 = 'erc721',
   Spl = 'spl',
   Nft = 'nft',
 }

--- a/packages/ui-components/src/lib/types/fireBlocks.ts
+++ b/packages/ui-components/src/lib/types/fireBlocks.ts
@@ -135,6 +135,11 @@ export interface GetOperationStatusResponse {
   };
 }
 
+export interface GetSolanaSplTransferResponse {
+  hash: string;
+  confirmed: boolean;
+}
+
 export interface GetTokenResponse {
   code?: 'SUCCESS' | 'PROCESSING';
   accessToken: string;
@@ -285,7 +290,10 @@ export interface VerifyTokenResponse {
 }
 
 export const isOperationResponseError = (
-  response: GetOperationResponse | GetOperationResponseError,
+  response: unknown,
 ): response is GetOperationResponseError => {
+  if (!response) {
+    return false;
+  }
   return typeof response === 'object' && 'code' in response;
 };

--- a/packages/ui-components/src/lib/wallet/asset.ts
+++ b/packages/ui-components/src/lib/wallet/asset.ts
@@ -34,6 +34,7 @@ export const getAsset = (
     if (opts?.token) {
       const isToken =
         opts.token.type === TokenType.Erc20 ||
+        opts.token.type === TokenType.Erc721 ||
         opts.token.type === TokenType.Spl;
       return (
         opts.token.walletName.toLowerCase() ===

--- a/packages/ui-components/src/lib/wallet/evm/abi.ts
+++ b/packages/ui-components/src/lib/wallet/evm/abi.ts
@@ -1,0 +1,13 @@
+export const erc721Abi = [
+  {
+    inputs: [
+      {name: 'from', type: 'address'},
+      {name: 'to', type: 'address'},
+      {name: 'tokenId', type: 'uint256'},
+    ],
+    name: 'safeTransferFrom',
+    outputs: [],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+] as const;

--- a/packages/ui-components/src/lib/wallet/evm/web3.ts
+++ b/packages/ui-components/src/lib/wallet/evm/web3.ts
@@ -1,9 +1,10 @@
 import {erc20Abi} from 'abitype/abis';
-import {erc721ABI} from 'wagmi';
 import {Web3} from 'web3';
 import {HttpProvider} from 'web3-providers-http';
 
 import config from '@unstoppabledomains/config';
+
+import {erc721Abi} from './abi';
 
 interface Web3Auth {
   chainSymbol: string;
@@ -38,7 +39,7 @@ export const getErc721Contract = (
   fromAddress?: string,
 ) => {
   const web3 = getWeb3(auth);
-  return new web3.eth.Contract(erc721ABI, address, {
+  return new web3.eth.Contract(erc721Abi, address, {
     from: fromAddress,
   });
 };

--- a/packages/ui-components/src/lib/wallet/evm/web3.ts
+++ b/packages/ui-components/src/lib/wallet/evm/web3.ts
@@ -1,4 +1,5 @@
 import {erc20Abi} from 'abitype/abis';
+import {erc721ABI} from 'wagmi';
 import {Web3} from 'web3';
 import {HttpProvider} from 'web3-providers-http';
 
@@ -10,7 +11,16 @@ interface Web3Auth {
   accessToken: string;
 }
 
-export const getContract = (
+export const getContractDecimals = async (
+  address: string,
+  auth: Web3Auth,
+): Promise<number> => {
+  const erc20Contract = getErc20Contract(address, auth);
+  const decimals = await erc20Contract.methods.decimals.call([]).call();
+  return Number(decimals);
+};
+
+export const getErc20Contract = (
   address: string,
   auth: Web3Auth,
   fromAddress?: string,
@@ -22,13 +32,15 @@ export const getContract = (
   });
 };
 
-export const getContractDecimals = async (
+export const getErc721Contract = (
   address: string,
   auth: Web3Auth,
-): Promise<number> => {
-  const erc20Contract = getContract(address, auth);
-  const decimals = await erc20Contract.methods.decimals.call([]).call();
-  return Number(decimals);
+  fromAddress?: string,
+) => {
+  const web3 = getWeb3(auth);
+  return new web3.eth.Contract(erc721ABI, address, {
+    from: fromAddress,
+  });
 };
 
 export const getWeb3 = (auth: Web3Auth): Web3 => {


### PR DESCRIPTION
Enables both NFT transfers for both EVM (ERC-721) and Solana (both SPL & Token22).

## Examples
### Unstoppable Domain transfer
https://polygonscan.com/tx/0x2f5eb38f9407362303c192db79206bf14282feecf8ddcf17f9800d692ba61857

